### PR TITLE
Remove cGuard code

### DIFF
--- a/BH/BH.cpp
+++ b/BH/BH.cpp
@@ -19,7 +19,6 @@ Config* BH::itemConfig;
 Drawing::UI* BH::settingsUI;
 Drawing::StatsDisplay* BH::statsDisplay;
 bool BH::initialized;
-bool BH::cGuardLoaded;
 WNDPROC BH::OldWNDPROC;
 map<string, Toggle>* BH::MiscToggles;
 map<string, Toggle>* BH::MiscToggles2;
@@ -49,21 +48,11 @@ unsigned int index = 0;
 bool BH::Startup(HINSTANCE instance, VOID* reserved) {
 
 	BH::instance = instance;
-	if (reserved != NULL) {
-		cGuardModule* pModule = (cGuardModule*)reserved;
-		if (!pModule)
-			return FALSE;
-		path.assign(pModule->szPath);
-		cGuardLoaded = true;
-	}
-	else {
-		char szPath[MAX_PATH];
-		GetModuleFileName(BH::instance, szPath, MAX_PATH);
-		PathRemoveFileSpec(szPath);
-		path.assign(szPath);
-		path += "\\";
-		cGuardLoaded = false;
-	}
+	char szPath[MAX_PATH];
+	GetModuleFileName(BH::instance, szPath, MAX_PATH);
+	PathRemoveFileSpec(szPath);
+	path.assign(szPath);
+	path += "\\";
 
 
 	initialized = false;

--- a/BH/BH.h
+++ b/BH/BH.h
@@ -43,7 +43,6 @@ namespace BH {
 	extern map<string, bool>* BnetBools;
 	extern map<string, bool>* GamefilterBools;
 	extern map<size_t, string> drops;
-	extern bool cGuardLoaded;
 	extern bool initialized;
 	extern Patch* oogDraw;
 

--- a/BH/D2Handlers.cpp
+++ b/BH/D2Handlers.cpp
@@ -123,7 +123,7 @@ BOOL __fastcall RealmPacketRecv(BYTE* pPacket) {
 DWORD __fastcall GamePacketRecv(BYTE* pPacket, DWORD dwSize) {
 	switch(pPacket[0])
 	{
-		case 0xAE: if(!BH::cGuardLoaded) return false; break;
+		case 0xAE: return false;
 		case 0x26: {
 			char* pName = (char*)pPacket+10;
 			char* pMessage = (char*)pPacket + strlen(pName) + 11;

--- a/BH/Modules/ScreenInfo/ScreenInfo.cpp
+++ b/BH/Modules/ScreenInfo/ScreenInfo.cpp
@@ -39,10 +39,6 @@ void ScreenInfo::OnLoad() {
 	d2VersionText->SetColor(White);
 	d2VersionText->SetFont(1);
 
-	if (BH::cGuardLoaded) {
-		Texthook* cGuardText = new Texthook(Perm, 790, 23, "�c4cGuard Loaded");
-		cGuardText->SetAlignment(Right);
-	}
 	gameTimer = GetTickCount();
 	nTotalGames = 0;
 	szGamesToLevel = "N/A";
@@ -565,9 +561,8 @@ std::string ScreenInfo::ReplaceAutomapTokens(std::string& v) {
 	return result;
 }
 
-void ScreenInfo::OnAutomapDraw() {		
-	int y = 6+(BH::cGuardLoaded?16:0);
-
+void ScreenInfo::OnAutomapDraw() {
+	int y = 6;
 	for (vector<string>::iterator it = automapInfo.begin(); it < automapInfo.end(); it++) {
 		string key = ReplaceAutomapTokens(*it);
 		if (key.length() > 0) {


### PR DESCRIPTION
This was useful for avoiding anticheat detection, but doesn't have any use, given that:

1. This project is designed for services without anti-cheat.
2. cGuard is probably now detected.