### PR TITLE
Add NOMINMAX preprocessor definition

### DIFF
--- a/BH.Injector/PEStructs.cpp
+++ b/BH.Injector/PEStructs.cpp
@@ -1,8 +1,10 @@
 #include "PEStructs.h"
+
+#include <algorithm>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <vector>
-#include <algorithm>
 
 using namespace std;
 
@@ -354,7 +356,7 @@ namespace PE {
 				uint funcOffset = RVAToOffset(exports.AddressOfFunctions, sec, nSec);
 				uint ordinalOffset = RVAToOffset(exports.AddressOfNameOrdinals, sec, nSec);
 
-				uint length = min(exports.NumberOfFunctions, exports.NumberOfNames);
+				uint length = std::min(exports.NumberOfFunctions, exports.NumberOfNames);
 
 				vector<string> names;
 				vector<uint> addresses;

--- a/BH/BH.vcxproj
+++ b/BH/BH.vcxproj
@@ -73,12 +73,12 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>kernel32.lib;shlwapi.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>
       </ModuleDefinitionFile>
     </Link>
@@ -99,13 +99,13 @@ if defined D2Path (
       <AdditionalIncludeDirectories>..\ThirdParty\cpp-lru-cache\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
-      <PreprocessorDefinitions>_WINDLL;$(CustomDefinitions);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_WINDLL;NOMINMAX;$(CustomDefinitions);%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>kernel32.lib;shlwapi.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>
       </ModuleDefinitionFile>
     </Link>
@@ -122,12 +122,13 @@ if defined D2Path (
       <Optimization>Disabled</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>kernel32.lib;shlwapi.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>
       </ModuleDefinitionFile>
     </Link>

--- a/BH/CMakeLists.txt
+++ b/BH/CMakeLists.txt
@@ -54,5 +54,6 @@ set(DRAWING_SOURCES "Drawing/Hook.cpp"
 
 set(SOURCE_FILES ${SOURCE_FILES} ${MODULE_SOURCES} ${DRAWING_SOURCES})
 add_library(BH SHARED ${SOURCE_FILES})
+target_compile_definitions(BH PRIVATE NOMINMAX)
 target_include_directories(BH PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../ThirdParty/cpp-lru-cache/include)
-target_link_libraries(BH ${STORM_LIBRARY} Shlwapi)
+target_link_libraries(BH Shlwapi)

--- a/BH/Common.cpp
+++ b/BH/Common.cpp
@@ -43,12 +43,17 @@
 *
 */
 
+#include "Common.h"
+
+#include <windows.h>
+
+#include <limits>
 #include <string>
 #include <vector>
-#include <Windows.h>
-#include "BH.h"
-#include "Common.h"
 #include <memory>
+
+#include "BH.h"
+
 using namespace std;
 
 void Tokenize(const string& str,
@@ -418,16 +423,16 @@ POINT CalculatePointOnTrack(const POINT& ptOrigin, int nRadius, int nAngle)
 POINT CalculateRandomPosition(const POINT& ptOrigin, int nRadiusMin, int nRadiusMax, int nAngleMin/*=0*/, int nAngleMax/*=360*/)
 {
 	// Data validation
-	nRadiusMin = max(0, nRadiusMin);
-	nRadiusMax = max(0, nRadiusMax);
+	nRadiusMin = std::max(0, nRadiusMin);
+	nRadiusMax = std::max(0, nRadiusMax);
 
 	NormalizeAngle(nAngleMin);
 	NormalizeAngle(nAngleMax);
 
-	const int R1 = min(nRadiusMin, nRadiusMax);
-	const int R2 = max(nRadiusMin, nRadiusMax);
-	const int A1 = min(nAngleMin, nAngleMax);
-	const int A2 = max(nAngleMin, nAngleMax);
+	const int R1 = std::min(nRadiusMin, nRadiusMax);
+	const int R2 = std::max(nRadiusMin, nRadiusMax);
+	const int A1 = std::min(nAngleMin, nAngleMax);
+	const int A2 = std::max(nAngleMin, nAngleMax);
 
 	const int R = (R1 == R2) ? R1 : (R1 + (::rand() % (R2 - R1))); // Final radius
 	const int A = (A1 == A2) ? A1 : (A1 + (::rand() % (A2 - A1))); // Final angle

--- a/BH/D2Helpers.cpp
+++ b/BH/D2Helpers.cpp
@@ -1,4 +1,7 @@
 #include "D2Helpers.h"
+
+#include <limits>
+
 #include "D2Ptrs.h"
 #include "D2Stubs.h"
 #include "Common.h"
@@ -181,7 +184,7 @@ CellFile *LoadBmpCellFile(BYTE *buf1, int width, int height)
 	for (int i = 0; i < height; i++) {
 		BYTE *src = buf1 + (i*((width + 3)&-4)), *limit = src + width;
 		while (src < limit) {
-			BYTE *start = src, *limit2 = min(limit, src + 0x7f), trans = !*src;
+			BYTE *start = src, *limit2 = std::min(limit, src + 0x7f), trans = !*src;
 			do src++; while ((trans == (BYTE)!*src) && (src < limit2));
 			if (!trans || (src < limit)) *dest++ = (trans ? 0x80 : 0) + (src - start);
 			if (!trans) while (start < src) *dest++ = *start++;

--- a/BH/Modules/AutoTele/ATIncludes/Matrix.h
+++ b/BH/Modules/AutoTele/ATIncludes/Matrix.h
@@ -23,6 +23,8 @@
 #include <windows.h>
 #include <search.h>
 #include <assert.h>
+
+#include <limits>
 #ifndef ASSERT
 #define ASSERT(x) assert(x)
 #endif
@@ -254,8 +256,8 @@ SIZE CMatrix<TYPE, ARG_TYPE>::ExportData(TYPE** ppBuffer, int cx, int cy) const
 	if (ppBuffer == NULL || cx <= 0 || cy <= 0 || !IsCreated())
 		return cz;
 
-	cz.cx = min(cx, m_cx);
-	cz.cy = min(cy, m_cy);
+	cz.cx = std::min(cx, m_cx);
+	cz.cy = std::min(cy, m_cy);
 
 	for (int i = 0; i < cz.cx; i++)
 	{

--- a/BH/Modules/AutoTele/ATIncludes/TeleportPath.h
+++ b/BH/Modules/AutoTele/ATIncludes/TeleportPath.h
@@ -19,6 +19,8 @@
 #include <math.h>
 //#include <stdio.h>
 
+#include <limits>
+
 class CTeleportPath  
 {
 public:	
@@ -203,7 +205,7 @@ DWORD CTeleportPath::FindTeleportPath(POINT ptStart, POINT ptEnd, LPPOINT lpBuff
 
 void CTeleportPath::Block(POINT pos, int nRange)
 {
-	nRange = max(nRange, 1);
+	nRange = std::max(nRange, 1);
 
 	for (int i = pos.x - nRange; i < pos.x + nRange; i++)
 	{

--- a/BH/Modules/Party/Party.cpp
+++ b/BH/Modules/Party/Party.cpp
@@ -1,4 +1,7 @@
 #include "Party.h"
+
+#include <limits>
+
 #include "../../D2Ptrs.h"
 #include "../../BH.h"
 #include "../../D2Stubs.h"
@@ -80,7 +83,7 @@ void Party::CheckParty() {
 		do {
 			if(!_stricmp(Party->szName, MyRoster->szName))
 				continue;
-			current_min_party_id = min(Party->wPartyId, current_min_party_id);
+			current_min_party_id = std::min(Party->wPartyId, current_min_party_id);
 		} while (Party=Party->pNext);
 
 		// third pass: do stuff


### PR DESCRIPTION
These changes add the NOMINMAX preprocessor definition to project files.

Windows headers files define a min and max macro that disrupt usage of functions named min and max. Because it of the way that the macro is defined, it can also lead to unusual double-function-call issues. All usage of the macro has been checked for this possibility, and it is safe to replace all uses of NOMIXMAX with std::min and std::max.