### PR TITLE
Refactor Trim into common::str_util::Trim

### DIFF
--- a/BH/BH.vcxproj
+++ b/BH/BH.vcxproj
@@ -194,6 +194,7 @@ if defined D2Path (
     <ClInclude Include="Common.h" />
     <ClInclude Include="CommonStructs.h" />
     <ClInclude Include="Common\Input.h" />
+    <ClInclude Include="Common\StringUtil.h" />
     <ClInclude Include="Config.h" />
     <ClInclude Include="Constants.h" />
     <ClInclude Include="D2DataTables.h" />
@@ -248,6 +249,11 @@ if defined D2Path (
     <ClInclude Include="Modules\StashExport\StashExport.h" />
     <ClInclude Include="TableReader.h" />
     <ClInclude Include="Task.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Common\StringUtilTemplate.inc">
+      <FileType>CppHeader</FileType>
+    </ClInclude>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/BH/BH.vcxproj.filters
+++ b/BH/BH.vcxproj.filters
@@ -109,5 +109,7 @@
     <ClInclude Include="TableReader.h" />
     <ClInclude Include="Task.h" />
     <ClInclude Include="Common\Input.h" />
+    <ClInclude Include="Common\StringUtil.h" />
+    <ClInclude Include="Common\StringUtilTemplate.inc" />
   </ItemGroup>
 </Project>

--- a/BH/Common.cpp
+++ b/BH/Common.cpp
@@ -100,14 +100,6 @@ std::wstring GetColorCode(int ColNo)
 	return Result.str();
 }
 
-std::string Trim(std::string source) {
-	source = source.erase(0, source.find_first_not_of(" "));
-	source = source.erase(source.find_last_not_of(" ") + 1);
-	source = source.erase(0, source.find_first_not_of("\t"));
-	source = source.erase(source.find_last_not_of("\t") + 1);
-	return source;
-}
-
 bool IsTrue(const char *str) {
 	return (_stricmp(str, "1") == 0 || _stricmp(str, "y") == 0 || _stricmp(str, "yes") == 0 || _stricmp(str, "true") == 0);
 }

--- a/BH/Common.h
+++ b/BH/Common.h
@@ -69,8 +69,6 @@ bool IsTrue(const char *str);
 bool StringToBool(std::string str);
 int StringToNumber(std::string str);
 
-std::string Trim(std::string source);
-
 void PrintText(DWORD Color, char *szText, ...);
 
 ULONGLONG BHGetTickCount(void);

--- a/BH/Common/StringUtil.h
+++ b/BH/Common/StringUtil.h
@@ -35,21 +35,21 @@ namespace common::str_util {
  */
 
 /**
- * Returns a view of the specified string, with the starting and
+ * Returns a copy of the specified string, with the starting and
  * ending whitespace removed.
  */
 template <typename CharT>
 std::basic_string<CharT> Trim(const CharT* str);
 
 /**
- * Returns a view of the specified string, with the starting and
+ * Returns a copy of the specified string, with the starting and
  * ending whitespace removed.
  */
 template <typename CharT>
 std::basic_string<CharT> Trim(const std::basic_string<CharT>& str);
 
 /**
- * Returns a view of the specified string, with the starting and
+ * Returns a copy of the specified string, with the starting and
  * ending whitespace removed.
  */
 template <typename CharT>

--- a/BH/Common/StringUtil.h
+++ b/BH/Common/StringUtil.h
@@ -1,0 +1,64 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) SlashDiablo Community
+ *
+ * BH
+ * Copyright 2011 (C) McGod
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef BH_COMMON_STRING_UTIL_H_
+#define BH_COMMON_STRING_UTIL_H_
+
+#include <string>
+#include <string_view>
+
+namespace common::str_util {
+
+/**
+ * String transformation functions
+ */
+
+/**
+ * Returns a view of the specified string, with the starting and
+ * ending whitespace removed.
+ */
+template <typename CharT>
+constexpr std::basic_string_view<CharT> Trim(const CharT* str);
+
+/**
+ * Returns a view of the specified string, with the starting and
+ * ending whitespace removed.
+ */
+template <typename CharT>
+constexpr std::basic_string_view<CharT> Trim(
+    const std::basic_string<CharT>& str);
+
+/**
+ * Returns a view of the specified string, with the starting and
+ * ending whitespace removed.
+ */
+template <typename CharT>
+constexpr std::basic_string_view<CharT> Trim(
+    std::basic_string_view<CharT> str);
+
+}  // namespace common::str_util
+
+#include "StringUtilTemplate.inc"
+
+#endif  // BH_COMMON_STRING_UTIL_H_

--- a/BH/Common/StringUtil.h
+++ b/BH/Common/StringUtil.h
@@ -39,23 +39,21 @@ namespace common::str_util {
  * ending whitespace removed.
  */
 template <typename CharT>
-constexpr std::basic_string_view<CharT> Trim(const CharT* str);
+std::basic_string<CharT> Trim(const CharT* str);
 
 /**
  * Returns a view of the specified string, with the starting and
  * ending whitespace removed.
  */
 template <typename CharT>
-constexpr std::basic_string_view<CharT> Trim(
-    const std::basic_string<CharT>& str);
+std::basic_string<CharT> Trim(const std::basic_string<CharT>& str);
 
 /**
  * Returns a view of the specified string, with the starting and
  * ending whitespace removed.
  */
 template <typename CharT>
-constexpr std::basic_string_view<CharT> Trim(
-    std::basic_string_view<CharT> str);
+std::basic_string<CharT> Trim(std::basic_string_view<CharT> str);
 
 }  // namespace common::str_util
 

--- a/BH/Common/StringUtilTemplate.inc
+++ b/BH/Common/StringUtilTemplate.inc
@@ -69,8 +69,8 @@ std::basic_string<CharT> Trim(std::basic_string_view<CharT> str) {
 
   size_type trim_back_index = str.find_last_not_of(kWhitespaceChars);
 
-  return str.substr(
-      trim_front_index, (trim_back_index + 1) - trim_front_index);
+  return std::basic_string<CharT>(
+      str.substr(trim_front_index, (trim_back_index + 1) - trim_front_index));
 }
 
 }  // namespace common::str_util

--- a/BH/Common/StringUtilTemplate.inc
+++ b/BH/Common/StringUtilTemplate.inc
@@ -1,0 +1,80 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) SlashDiablo Community
+ *
+ * BH
+ * Copyright 2011 (C) McGod
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#if !defined(BH_COMMON_STRING_UTIL_H_)
+#error This file is not to be directly included by external users.
+#endif  // !defined(BH_COMMON_STRING_UTIL_H_)
+
+#ifndef BH_COMMON_STRING_UTIL_TEMPLATE_INC_
+#define BH_COMMON_STRING_UTIL_TEMPLATE_INC_
+
+#include <string>
+#include <string_view>
+
+namespace common::str_util {
+
+/**
+ * String transformation functions
+ */
+
+template <typename CharT>
+constexpr std::basic_string_view<CharT> Trim(const CharT* str) {
+  return Trim<CharT>(std::basic_string_view<CharT>(str));
+}
+
+template <typename CharT>
+constexpr std::basic_string_view<CharT> Trim(
+    const std::basic_string<CharT>& str) {
+  return Trim<CharT>(std::basic_string_view<CharT>(str));
+}
+
+template <typename CharT>
+constexpr std::basic_string_view<CharT> Trim(
+    std::basic_string_view<CharT> str) {
+  using size_type = typename std::basic_string_view<CharT>::size_type;
+
+  static constexpr CharT kWhitespaceChars[] = {
+    CharT(' '),
+    CharT('\f'),
+    CharT('\n'),
+    CharT('\r'),
+    CharT('\t'),
+    CharT('\v'),
+    CharT('\0')
+  };
+
+  size_type trim_front_index = str.find_first_not_of(kWhitespaceChars);
+  if (trim_front_index == std::basic_string_view<CharT>::npos) {
+    return std::basic_string_view<CharT>();
+  }
+
+  size_type trim_back_index = str.find_last_not_of(kWhitespaceChars);
+
+  return str.substr(
+      trim_front_index, (trim_back_index + 1) - trim_front_index);
+}
+
+}  // namespace common::str_util
+
+#endif  // BH_COMMON_STRING_UTIL_TEMPLATE_INC_

--- a/BH/Common/StringUtilTemplate.inc
+++ b/BH/Common/StringUtilTemplate.inc
@@ -39,19 +39,17 @@ namespace common::str_util {
  */
 
 template <typename CharT>
-constexpr std::basic_string_view<CharT> Trim(const CharT* str) {
+std::basic_string<CharT> Trim(const CharT* str) {
   return Trim<CharT>(std::basic_string_view<CharT>(str));
 }
 
 template <typename CharT>
-constexpr std::basic_string_view<CharT> Trim(
-    const std::basic_string<CharT>& str) {
+std::basic_string<CharT> Trim(const std::basic_string<CharT>& str) {
   return Trim<CharT>(std::basic_string_view<CharT>(str));
 }
 
 template <typename CharT>
-constexpr std::basic_string_view<CharT> Trim(
-    std::basic_string_view<CharT> str) {
+std::basic_string<CharT> Trim(std::basic_string_view<CharT> str) {
   using size_type = typename std::basic_string_view<CharT>::size_type;
 
   static constexpr CharT kWhitespaceChars[] = {
@@ -66,7 +64,7 @@ constexpr std::basic_string_view<CharT> Trim(
 
   size_type trim_front_index = str.find_first_not_of(kWhitespaceChars);
   if (trim_front_index == std::basic_string_view<CharT>::npos) {
-    return std::basic_string_view<CharT>();
+    return std::basic_string<CharT>();
   }
 
   size_type trim_back_index = str.find_last_not_of(kWhitespaceChars);

--- a/BH/Config.cpp
+++ b/BH/Config.cpp
@@ -63,12 +63,14 @@ bool Config::Parse() {
 		// Parse the key and value.
 		size_t keyValueDelimiterIndex = line.find_first_of(":");
 
-		std::string_view keyStr(line.c_str(), keyValueDelimiterIndex);
-		entry.key.assign(Trim(keyStr));
+		std::string_view rawKeyStr(line.c_str(), keyValueDelimiterIndex);
+		std::string keyStr = Trim(rawKeyStr);
+		entry.key = std::move(keyStr);
 
-		std::string_view valueStr(line);
-		valueStr.remove_prefix(keyValueDelimiterIndex + 1);
-		entry.value.assign(Trim(valueStr));
+		std::string_view rawValueStr(line);
+		rawValueStr.remove_prefix(keyValueDelimiterIndex + 1);
+		std::string valueStr = Trim(rawValueStr);
+		entry.value = std::move(valueStr);
 
 		entry.comment = line.substr(keyValueDelimiterIndex + 1, line.find(entry.value) - keyValueDelimiterIndex - 1);
 		entry.pointer = NULL;
@@ -291,7 +293,7 @@ Toggle Config::ReadToggle(std::string key, std::string toggle, bool state, Toggl
 	// Read state string.
 	std::string_view rawStateStr(
 			contents[key].value.c_str(), stateVkeydelimiterIndex);
-	std::string_view stateStr = Trim(rawStateStr);
+	std::string stateStr = Trim(rawStateStr);
 
 	// Read virtual-key string and get mapped code.
 	std::string_view rawVirtualKeyStr(contents[key].value);
@@ -303,7 +305,7 @@ Toggle Config::ReadToggle(std::string key, std::string toggle, bool state, Toggl
 			virtualKeyOptional.value_or(VirtualKey::GetUnset());
 
 	ret.toggle = virtualKey.code;
-	ret.state = StringToBool(Trim(stateStr));
+	ret.state = StringToBool(stateStr);
 
 	value = ret;
 	return ret;

--- a/BH/Config.cpp
+++ b/BH/Config.cpp
@@ -64,13 +64,11 @@ bool Config::Parse() {
 		size_t keyValueDelimiterIndex = line.find_first_of(":");
 
 		std::string_view rawKeyStr(line.c_str(), keyValueDelimiterIndex);
-		std::string keyStr = Trim(rawKeyStr);
-		entry.key = std::move(keyStr);
+		entry.key = Trim(rawKeyStr);
 
 		std::string_view rawValueStr(line);
 		rawValueStr.remove_prefix(keyValueDelimiterIndex + 1);
-		std::string valueStr = Trim(rawValueStr);
-		entry.value = std::move(valueStr);
+		entry.value = Trim(rawValueStr);
 
 		entry.comment = line.substr(keyValueDelimiterIndex + 1, line.find(entry.value) - keyValueDelimiterIndex - 1);
 		entry.pointer = NULL;
@@ -591,6 +589,7 @@ bool Config::HasChanged(ConfigEntry entry, std::string& value) {
 		std::string_view rawOldStateStr(
 				entry.value.c_str(), stateVkeydelimiterIndex);
 		std::string oldStateStr = Trim(rawOldStateStr);
+		bool oldState = StringToBool(std::move(oldStateStr));
 
 		// Get the virtual-key for the old Toggle.
 		std::string_view rawOldVirtualKeyStr(
@@ -598,8 +597,6 @@ bool Config::HasChanged(ConfigEntry entry, std::string& value) {
 		std::string oldVirtualKeyStr = Trim(rawOldVirtualKeyStr);
 		std::optional<VirtualKey> oldVirtualKeyOptional =
 				VirtualKey::GetFromSymbolName(oldVirtualKeyStr);
-
-		bool oldState = StringToBool(std::move(oldStateStr));
 		VirtualKey oldVirtualKey =
 				oldVirtualKeyOptional.value_or(VirtualKey::GetUnset());
 

--- a/BH/Config.cpp
+++ b/BH/Config.cpp
@@ -303,7 +303,7 @@ Toggle Config::ReadToggle(std::string key, std::string toggle, bool state, Toggl
 			virtualKeyOptional.value_or(VirtualKey::GetUnset());
 
 	ret.toggle = virtualKey.code;
-	ret.state = StringToBool(stateStr);
+	ret.state = StringToBool(Trim(stateStr));
 
 	value = ret;
 	return ret;

--- a/BH/Drawing/Stats/StatsDisplay.cpp
+++ b/BH/Drawing/Stats/StatsDisplay.cpp
@@ -1,9 +1,17 @@
 #include "StatsDisplay.h"
+
+#include "../../BH.h"
+#include "../../Common/StringUtil.h"
+#include "../../D2Ptrs.h"
 #include "../Basic/Texthook/Texthook.h"
 #include "../Basic/Framehook/Framehook.h"
 #include "../Basic/Boxhook/Boxhook.h"
-#include "../../D2Ptrs.h"
-#include "../../BH.h"
+
+namespace {
+
+using ::common::str_util::Trim;
+
+}  // namespace
 
 using namespace Drawing;
 

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -1,5 +1,13 @@
 #include "ItemDisplay.h"
+
+#include "../../Common/StringUtil.h"
 #include "Item.h"
+
+namespace {
+
+using ::common::str_util::Trim;
+
+}  // namespace
 
 // All the types able to be combined with the + operator
 #define COMBO_STATS					\
@@ -830,9 +838,12 @@ void Condition::BuildConditions(std::vector<Condition*> &conditions, std::string
 	int value = 0;
 	std::string valueStr;
 	if (delPos != std::string::npos) {
-		key = Trim(token.substr(0, delPos));
+		key = Trim(std::string_view(token.c_str(), delPos));
 		delim = token.substr(delPos, 1);
-		valueStr = Trim(token.substr(delPos + 1));
+		valueStr =
+				Trim(
+						std::string_view(
+								token.c_str() + delPos + 1, token.length() - (delPos + 1)));
 		if (valueStr.length() > 0) {
 			std::stringstream ss(valueStr);
 			if ((ss >> value).fail()) {

--- a/BH/Modules/StashExport/StashExport.cpp
+++ b/BH/Modules/StashExport/StashExport.cpp
@@ -1,13 +1,22 @@
 #include "StashExport.h"
-#include "../../D2Ptrs.h"
+
+#include <algorithm>
+
 #include "../../BH.h"
+#include "../../Common/StringUtil.h"
+#include "../../Constants.h"
+#include "../../D2Ptrs.h"
 #include "../../D2Stubs.h"
+#include "../../MPQInit.h"
+#include "../../TableReader.h"
 #include "../Item/ItemDisplay.h"
 #include "../Item/Item.h"
-#include "../../TableReader.h"
-#include "../../MPQInit.h"
-#include "../../Constants.h"
-#include <algorithm>
+
+namespace {
+
+using ::common::str_util::Trim;
+
+}  // namespace
 
 std::map<std::string, Toggle> StashExport::Toggles;
 std::map<std::string, std::unique_ptr<Mustache::AMustacheTemplate>> StashExport::MustacheTemplates;
@@ -220,8 +229,7 @@ void StashExport::GetItemInfo(UnitAny* pItem, JSONObject* pBuffer){
 		txt->szCode[3],
 		0
 	};
-	std::string code = cCode;
-	code = Trim(code);
+	std::string code(Trim(cCode));
 
 	BYTE nType = txt->nType;
 	if (nType >= 96 && nType <= 102) { // is gem?

--- a/BH/Modules/StashExport/StashExport.cpp
+++ b/BH/Modules/StashExport/StashExport.cpp
@@ -229,7 +229,7 @@ void StashExport::GetItemInfo(UnitAny* pItem, JSONObject* pBuffer){
 		txt->szCode[3],
 		0
 	};
-	std::string code(Trim(cCode));
+	std::string code = Trim(cCode);
 
 	BYTE nType = txt->nType;
 	if (nType >= 96 && nType <= 102) { // is gem?


### PR DESCRIPTION
These changes refactor the Trim function into template functions that do not require unnecessary string allocations.