### PR TITLE
Remove all uses of "using namespace Drawing;"

### DIFF
--- a/BH/Drawing/Advanced/Checkhook/Checkhook.cpp
+++ b/BH/Drawing/Advanced/Checkhook/Checkhook.cpp
@@ -3,7 +3,8 @@
 #include "../../../D2Ptrs.h"
 #include "../../Basic/Framehook/Framehook.h"
 
-using namespace Drawing;
+namespace Drawing {
+
 /* Basic Hook Initializer
  *		Used for drawing a checkbox on screen.
  */
@@ -180,3 +181,5 @@ bool Checkhook::OnRightClick(bool up, unsigned int x, unsigned int y) {
 	}
 	return false;
 }
+
+}  // namespace Drawing

--- a/BH/Drawing/Advanced/Checkhook/Checkhook.h
+++ b/BH/Drawing/Advanced/Checkhook/Checkhook.h
@@ -4,52 +4,54 @@
 #include "../../Basic/Texthook/Texthook.h"
 
 namespace Drawing {
-	class Checkhook : public Hook {
-		private:
-			bool* state;//Holds if the checkbox is checked.
-			TextColor color, hoverColor;//Holds text color/hover color.
-			std::string text;//The text beside the checkhook.
-		public:
-			Checkhook(HookVisibility visibility, unsigned int x, unsigned int y, bool* checked, std::string formatString, ...);
-			Checkhook(HookGroup* group, unsigned int x, unsigned int y, bool* checked, std::string formatString, ...);
 
-			//Returns if the check is checked.
-			bool IsChecked();
+class Checkhook : public Hook {
+	private:
+		bool* state;//Holds if the checkbox is checked.
+		TextColor color, hoverColor;//Holds text color/hover color.
+		std::string text;//The text beside the checkhook.
+	public:
+		Checkhook(HookVisibility visibility, unsigned int x, unsigned int y, bool* checked, std::string formatString, ...);
+		Checkhook(HookGroup* group, unsigned int x, unsigned int y, bool* checked, std::string formatString, ...);
 
-			//Sets if it is checked or not.
-			void SetState(bool checked);
+		//Returns if the check is checked.
+		bool IsChecked();
 
-			//Returns the text color.
-			TextColor GetTextColor();
+		//Sets if it is checked or not.
+		void SetState(bool checked);
 
-			//Returns the hover color
-			TextColor GetHoverColor();
+		//Returns the text color.
+		TextColor GetTextColor();
 
-			//Sets the text color
-			void SetTextColor(TextColor newColor);
+		//Returns the hover color
+		TextColor GetHoverColor();
 
-			//Sets the hover color
-			void SetHoverColor(TextColor newColor);
+		//Sets the text color
+		void SetTextColor(TextColor newColor);
 
-			//Gets the text
-			std::string GetText();
+		//Sets the hover color
+		void SetHoverColor(TextColor newColor);
 
-			//Sets the text
-			void SetText(std::string formatString, ...);
+		//Gets the text
+		std::string GetText();
 
-			//Returns the total width of the check hook
-			unsigned int GetXSize();
+		//Sets the text
+		void SetText(std::string formatString, ...);
 
-			//Returns the total hright of the check hook
-			unsigned int GetYSize();
+		//Returns the total width of the check hook
+		unsigned int GetXSize();
 
-			//Draw the text.
-			void OnDraw();
+		//Returns the total hright of the check hook
+		unsigned int GetYSize();
 
-			//Checks if we've been clicked on and calls the handler if so.
-			bool OnLeftClick(bool up, unsigned int x, unsigned int y);
+		//Draw the text.
+		void OnDraw();
 
-			//Checks if we've been clicked on and calls the handler if so.
-			bool OnRightClick(bool up, unsigned int x, unsigned int y);
-	};
+		//Checks if we've been clicked on and calls the handler if so.
+		bool OnLeftClick(bool up, unsigned int x, unsigned int y);
+
+		//Checks if we've been clicked on and calls the handler if so.
+		bool OnRightClick(bool up, unsigned int x, unsigned int y);
 };
+
+}  // namespace Drawing

--- a/BH/Drawing/Advanced/Colorhook/Colorhook.cpp
+++ b/BH/Drawing/Advanced/Colorhook/Colorhook.cpp
@@ -6,7 +6,7 @@
 #include "../../Basic/Texthook/Texthook.h"
 #include "../../Basic/Crosshook/Crosshook.h"
 
-using namespace Drawing;
+namespace Drawing {
 
 Colorhook* Colorhook::current;
 
@@ -145,3 +145,5 @@ void Colorhook::OnDraw() {
 	}
 	Unlock();
 }
+
+}  // namespace Drawing

--- a/BH/Drawing/Advanced/Colorhook/Colorhook.h
+++ b/BH/Drawing/Advanced/Colorhook/Colorhook.h
@@ -3,31 +3,33 @@
 #include "../../Hook.h"
 
 namespace Drawing {
-	class Colorhook;
 
-	class Colorhook : public Hook {
-		private:
-			std::string text;//Text to have linked
-			unsigned int* currentColor;//Color that we will be changing
-			unsigned int curColor;
-		public:
-			static Colorhook* current;//Pointer to the current colorhook
+class Colorhook;
 
-			//Two Hook Initializations; one for basic hooks, one for grouped hooks.
-			Colorhook(HookVisibility visibility, unsigned int x, unsigned int y, unsigned int* color, std::string formatString, ...);
-			Colorhook(HookGroup* group, unsigned int x, unsigned int y, unsigned int* color, std::string formatString, ...);
+class Colorhook : public Hook {
+	private:
+		std::string text;//Text to have linked
+		unsigned int* currentColor;//Color that we will be changing
+		unsigned int curColor;
+	public:
+		static Colorhook* current;//Pointer to the current colorhook
 
-			std::string GetText() { return text; };
-			void SetText(std::string newText);
+		//Two Hook Initializations; one for basic hooks, one for grouped hooks.
+		Colorhook(HookVisibility visibility, unsigned int x, unsigned int y, unsigned int* color, std::string formatString, ...);
+		Colorhook(HookGroup* group, unsigned int x, unsigned int y, unsigned int* color, std::string formatString, ...);
 
-			unsigned int GetColor() { return *currentColor; };
-			void SetColor(unsigned int newColor);
+		std::string GetText() { return text; };
+		void SetText(std::string newText);
 
-			bool OnLeftClick(bool up, unsigned int x, unsigned int y);
-			bool OnRightClick(bool up, unsigned int x, unsigned int y);
-			void OnDraw();
+		unsigned int GetColor() { return *currentColor; };
+		void SetColor(unsigned int newColor);
 
-			unsigned int GetXSize();
-			unsigned int GetYSize();
-	};
+		bool OnLeftClick(bool up, unsigned int x, unsigned int y);
+		bool OnRightClick(bool up, unsigned int x, unsigned int y);
+		void OnDraw();
+
+		unsigned int GetXSize();
+		unsigned int GetYSize();
 };
+
+}  // namespace Drawing

--- a/BH/Drawing/Advanced/Combohook/Combohook.cpp
+++ b/BH/Drawing/Advanced/Combohook/Combohook.cpp
@@ -3,7 +3,7 @@
 #include "../../Basic/Texthook/Texthook.h"
 #include "../../../D2Ptrs.h"
 
-using namespace Drawing;
+namespace Drawing {
 
 Combohook::Combohook(HookVisibility visibility, unsigned int x, unsigned int y, unsigned int xSize, unsigned int* index, std::vector<std::string> opts)
 	: Hook(visibility, x, y) {
@@ -68,3 +68,5 @@ void Combohook::OnDraw() {
 		}
 	}
 }
+
+}  // namespace Drawing

--- a/BH/Drawing/Advanced/Combohook/Combohook.h
+++ b/BH/Drawing/Advanced/Combohook/Combohook.h
@@ -3,33 +3,35 @@
 #include "../../Hook.h"
 
 namespace Drawing {
-	class Combohook : public Hook {
-		private:
-			std::vector<std::string> options;
-			unsigned int xSize;
-			unsigned int font;
-			unsigned int* currentIndex;
-			bool active;
-		public:
-			Combohook(HookVisibility visibility, unsigned int x, unsigned int y, unsigned int xSize, unsigned int* currentIndex, std::vector<std::string> options);
-			Combohook(HookGroup* group, unsigned int x, unsigned int y, unsigned int xSize, unsigned int* currentIndex, std::vector<std::string> options);
 
-			std::vector<std::string> GetOptions() { return options; };
-			unsigned int NewOption(std::string opt) { Lock(); options.push_back(opt); Unlock(); return options.size() - 1; };
-			unsigned int GetSelectedIndex() { return *currentIndex; };
-			void SetSelectedIndex(unsigned int index) { if (index > options.size()) { return; } Lock(); *currentIndex = index; Unlock(); };
+class Combohook : public Hook {
+	private:
+		std::vector<std::string> options;
+		unsigned int xSize;
+		unsigned int font;
+		unsigned int* currentIndex;
+		bool active;
+	public:
+		Combohook(HookVisibility visibility, unsigned int x, unsigned int y, unsigned int xSize, unsigned int* currentIndex, std::vector<std::string> options);
+		Combohook(HookGroup* group, unsigned int x, unsigned int y, unsigned int xSize, unsigned int* currentIndex, std::vector<std::string> options);
 
-			unsigned int GetFont() { return font; };
-			void SetFont(unsigned int newFont) { Lock(); font = newFont; Unlock(); };
+		std::vector<std::string> GetOptions() { return options; };
+		unsigned int NewOption(std::string opt) { Lock(); options.push_back(opt); Unlock(); return options.size() - 1; };
+		unsigned int GetSelectedIndex() { return *currentIndex; };
+		void SetSelectedIndex(unsigned int index) { if (index > options.size()) { return; } Lock(); *currentIndex = index; Unlock(); };
 
-			unsigned int GetXSize() { return xSize; };
-			void SetXSize(unsigned int size) { Lock(); xSize = size; Unlock(); };
+		unsigned int GetFont() { return font; };
+		void SetFont(unsigned int newFont) { Lock(); font = newFont; Unlock(); };
 
-			unsigned int GetYSize() { unsigned int height[] = {10,11,18,24,10,13,7,13,10,12,8,8,7,12}; return height[GetFont()]; };
+		unsigned int GetXSize() { return xSize; };
+		void SetXSize(unsigned int size) { Lock(); xSize = size; Unlock(); };
 
-			bool OnLeftClick(bool up, unsigned int x, unsigned int y);
-			void OnDraw();
+		unsigned int GetYSize() { unsigned int height[] = {10,11,18,24,10,13,7,13,10,12,8,8,7,12}; return height[GetFont()]; };
 
-			bool InHook(unsigned int nx, unsigned int ny) { return nx >= GetX() && ny >= GetY() && nx <= GetX() + GetXSize() + 5 && ny <= GetY() + GetYSize() + 3; };
-	};
+		bool OnLeftClick(bool up, unsigned int x, unsigned int y);
+		void OnDraw();
+
+		bool InHook(unsigned int nx, unsigned int ny) { return nx >= GetX() && ny >= GetY() && nx <= GetX() + GetXSize() + 5 && ny <= GetY() + GetYSize() + 3; };
 };
+
+}  // namespace Drawing

--- a/BH/Drawing/Advanced/Inputhook/Inputhook.cpp
+++ b/BH/Drawing/Advanced/Inputhook/Inputhook.cpp
@@ -3,7 +3,7 @@
 #include "../../Basic/Framehook/Framehook.h"
 #include "../../../Common.h"
 
-using namespace Drawing;
+namespace Drawing {
 
 Inputhook::Inputhook(HookVisibility visibility, unsigned int x, unsigned int y, unsigned int xSize, std::string formatString, ...) :
  Hook(visibility, x, y) {
@@ -343,3 +343,5 @@ void Inputhook::Erase(unsigned int pos, unsigned int len) {
 	SetCursorPosition(pos);
 	Unlock();
 }
+
+}  // namespace Drawing

--- a/BH/Drawing/Advanced/Inputhook/Inputhook.h
+++ b/BH/Drawing/Advanced/Inputhook/Inputhook.h
@@ -5,76 +5,78 @@
 #include "../../Basic/Texthook/Texthook.h"
 
 namespace Drawing {
-	class Inputhook : public Hook {
-		private:
-			std::string text; //Text that is actually in the input box
-			bool active, showCursor; //Booleans set if the hook is active / currently showing cursor.
-			unsigned int xSize; //Length of the input box
-			unsigned int cursorPos, cursorTick; //Cursor Position / Timer to control cursor blink
-			unsigned int textPos;//Used to determine which part of the current text I should show
-			unsigned int selectPos, selectLength; // Selection position and length
-			unsigned int font; //What type of font to use in the input hook.
-		public:
-			Inputhook(HookVisibility visibility, unsigned int x, unsigned int y, unsigned int xSize, std::string formatString, ...);
-			Inputhook(HookGroup* group, unsigned int x, unsigned int y, unsigned int xSize, std::string formatString, ...);
 
-			//Getters and Setters
+class Inputhook : public Hook {
+	private:
+		std::string text; //Text that is actually in the input box
+		bool active, showCursor; //Booleans set if the hook is active / currently showing cursor.
+		unsigned int xSize; //Length of the input box
+		unsigned int cursorPos, cursorTick; //Cursor Position / Timer to control cursor blink
+		unsigned int textPos;//Used to determine which part of the current text I should show
+		unsigned int selectPos, selectLength; // Selection position and length
+		unsigned int font; //What type of font to use in the input hook.
+	public:
+		Inputhook(HookVisibility visibility, unsigned int x, unsigned int y, unsigned int xSize, std::string formatString, ...);
+		Inputhook(HookGroup* group, unsigned int x, unsigned int y, unsigned int xSize, std::string formatString, ...);
 
-			//Text in the input box
-			std::string GetText() { return text; };
-			void SetText(std::string newText, ...);
+		//Getters and Setters
 
-			//If the inputhook box is active(Can be typed in)
-			bool IsActive() { return active; };
-			void SetActive(bool isActive) { Lock(); active = isActive; Unlock(); };
+		//Text in the input box
+		std::string GetText() { return text; };
+		void SetText(std::string newText, ...);
 
-			//Font Size
-			unsigned int GetFont() { return font; };
-			void SetFont(unsigned int newFont);
+		//If the inputhook box is active(Can be typed in)
+		bool IsActive() { return active; };
+		void SetActive(bool isActive) { Lock(); active = isActive; Unlock(); };
 
-			//X Size
-			unsigned int GetXSize() { return xSize; };
-			void SetXSize(unsigned int newXSize);
+		//Font Size
+		unsigned int GetFont() { return font; };
+		void SetFont(unsigned int newFont);
 
-			//Y Size
-			unsigned int GetYSize() { unsigned int height[] = {10,11,18,24,10,13,7,13,10,12,8,8,7,12}; return height[GetFont()]; };
+		//X Size
+		unsigned int GetXSize() { return xSize; };
+		void SetXSize(unsigned int newXSize);
 
-			//If we are current showing the cursor, for blinking purposes!
-			bool ShowCursor() { return showCursor; };
-			void SetCursorState(bool state) { Lock(); showCursor = state; Unlock(); };
-			void ToggleCursor() { SetCursorState(!ShowCursor()); };
+		//Y Size
+		unsigned int GetYSize() { unsigned int height[] = {10,11,18,24,10,13,7,13,10,12,8,8,7,12}; return height[GetFont()]; };
 
-			void CursorTick();
-			void ResetCursorTick() { cursorTick = 0; };
+		//If we are current showing the cursor, for blinking purposes!
+		bool ShowCursor() { return showCursor; };
+		void SetCursorState(bool state) { Lock(); showCursor = state; Unlock(); };
+		void ToggleCursor() { SetCursorState(!ShowCursor()); };
 
-			unsigned int GetCursorPosition() { return cursorPos; };
-			void SetCursorPosition(unsigned int newPosition);
-			void IncreaseCursorPosition(unsigned int len);
-			void DecreaseCursorPosition(unsigned int len);
+		void CursorTick();
+		void ResetCursorTick() { cursorTick = 0; };
 
-			unsigned int GetSelectionPosition() { return selectPos; };
-			void SetSelectionPosition(unsigned int pos);
+		unsigned int GetCursorPosition() { return cursorPos; };
+		void SetCursorPosition(unsigned int newPosition);
+		void IncreaseCursorPosition(unsigned int len);
+		void DecreaseCursorPosition(unsigned int len);
 
-			unsigned int GetSelectionLength() { return selectLength; };
-			void SetSelectionLength(unsigned int length);
+		unsigned int GetSelectionPosition() { return selectPos; };
+		void SetSelectionPosition(unsigned int pos);
 
-			bool IsSelected() { return selectLength > 0; };
-			void ResetSelection() { Lock(); selectPos = 0; selectLength = 0; Unlock(); };
-		
-			bool OnKey(bool up, BYTE key, LPARAM lParam);
-			bool OnLeftClick(bool up, unsigned int x, unsigned int y);
-			bool OnRightClick(bool up, unsigned int x, unsigned int y);
+		unsigned int GetSelectionLength() { return selectLength; };
+		void SetSelectionLength(unsigned int length);
 
-			unsigned int GetCharacterLimit();
+		bool IsSelected() { return selectLength > 0; };
+		void ResetSelection() { Lock(); selectPos = 0; selectLength = 0; Unlock(); };
+	
+		bool OnKey(bool up, BYTE key, LPARAM lParam);
+		bool OnLeftClick(bool up, unsigned int x, unsigned int y);
+		bool OnRightClick(bool up, unsigned int x, unsigned int y);
 
-			unsigned int GetTextPos() { return textPos; };
-			void SetTextPos(unsigned int pos) { Lock(); textPos = pos; Unlock(); };
+		unsigned int GetCharacterLimit();
 
-			void OnDraw();
+		unsigned int GetTextPos() { return textPos; };
+		void SetTextPos(unsigned int pos) { Lock(); textPos = pos; Unlock(); };
 
-			void InputText(std::string newText);
-			void Backspace();
-			void Replace(unsigned int pos, unsigned int len, std::string str);
-			void Erase(unsigned int pos, unsigned int len);
-	};
+		void OnDraw();
+
+		void InputText(std::string newText);
+		void Backspace();
+		void Replace(unsigned int pos, unsigned int len, std::string str);
+		void Erase(unsigned int pos, unsigned int len);
 };
+
+}  // namespace Drawing

--- a/BH/Drawing/Advanced/Keyhook/Keyhook.cpp
+++ b/BH/Drawing/Advanced/Keyhook/Keyhook.cpp
@@ -6,11 +6,11 @@
 
 namespace {
 
-using common::input::VirtualKey;
+using ::common::input::VirtualKey;
 
-} // namespace
+}  // namespace
 
-using namespace Drawing;
+namespace Drawing {
 
 /* Basic Hook Initializer
  *		Used for just drawing basics.
@@ -110,3 +110,5 @@ unsigned int Keyhook::GetXSize() {
 unsigned int Keyhook::GetYSize() {
 	return 10;
 }
+
+}  // namespace Drawing

--- a/BH/Drawing/Advanced/Keyhook/Keyhook.h
+++ b/BH/Drawing/Advanced/Keyhook/Keyhook.h
@@ -3,27 +3,29 @@
 #include "../../Hook.h"
 
 namespace Drawing {
-	class Keyhook : public Hook {
-		private:
-			unsigned int* key;//Pointer to the current key
-			std::string name;//Name of the hotkey
-			unsigned int timeout;//Timeout to change hotkey if clicked
-		public:
-			//Two Hook Initializations; one for basic hooks, one for grouped hooks.
-			Keyhook(HookVisibility visibility, unsigned int x, unsigned int y, unsigned int* key, std::string hotkeyName);
-			Keyhook(HookGroup* group, unsigned int x, unsigned int y, unsigned int* key, std::string hotkeyName);
 
-			std::string GetName() { return name; };
-			void SetName(std::string newName) { Lock(); name = newName; Unlock(); };
+class Keyhook : public Hook {
+	private:
+		unsigned int* key;//Pointer to the current key
+		std::string name;//Name of the hotkey
+		unsigned int timeout;//Timeout to change hotkey if clicked
+	public:
+		//Two Hook Initializations; one for basic hooks, one for grouped hooks.
+		Keyhook(HookVisibility visibility, unsigned int x, unsigned int y, unsigned int* key, std::string hotkeyName);
+		Keyhook(HookGroup* group, unsigned int x, unsigned int y, unsigned int* key, std::string hotkeyName);
 
-			unsigned int GetKey() { return *key; };
-			void SetKey(unsigned int* newKey) { Lock(); key = newKey; Unlock(); };
+		std::string GetName() { return name; };
+		void SetName(std::string newName) { Lock(); name = newName; Unlock(); };
 
-			bool OnLeftClick(bool up, unsigned int x, unsigned int y);
-			void OnDraw();
-			bool OnKey(bool up, BYTE key, LPARAM lParam);
+		unsigned int GetKey() { return *key; };
+		void SetKey(unsigned int* newKey) { Lock(); key = newKey; Unlock(); };
 
-			unsigned int GetXSize();
-			unsigned int GetYSize();
-	};
+		bool OnLeftClick(bool up, unsigned int x, unsigned int y);
+		void OnDraw();
+		bool OnKey(bool up, BYTE key, LPARAM lParam);
+
+		unsigned int GetXSize();
+		unsigned int GetYSize();
 };
+
+}  // namespace Drawing

--- a/BH/Drawing/Basic/Boxhook/Boxhook.cpp
+++ b/BH/Drawing/Basic/Boxhook/Boxhook.cpp
@@ -2,7 +2,7 @@
 #include "../../../Common.h"
 #include "../../../D2Ptrs.h"
 
-using namespace Drawing;
+namespace Drawing {
 
 /* Basic Hook Initializer
  *		Used for just drawing basic boxes on screen.
@@ -139,3 +139,5 @@ bool Boxhook::Draw(unsigned int x, unsigned int y, unsigned int xSize, unsigned 
 	D2GFX_DrawRectangle(x, y, x + xSize, y + ySize, color, trans);
 	return true;
 }
+
+}  // namespace Drawing

--- a/BH/Drawing/Basic/Boxhook/Boxhook.h
+++ b/BH/Drawing/Basic/Boxhook/Boxhook.h
@@ -3,54 +3,56 @@
 #include "../../Hook.h"
 
 namespace Drawing {
-	class Boxhook : public Hook {
-		private:
-			unsigned int color;//Color of the box hook 0-255.
-			unsigned int xSize, ySize;//Size of the box hook.
-			BoxTrans transparency;//Type of transparency.
 
-		public:
-			//Boxhook Initaliztors, one for basic hooks and one for groups.
-			Boxhook(HookVisibility visiblity, unsigned int x, unsigned int y, unsigned int xSize, unsigned int ySize);
-			Boxhook(HookGroup* group, unsigned int x, unsigned int y, unsigned int xSize, unsigned int ySize);
+class Boxhook : public Hook {
+	private:
+		unsigned int color;//Color of the box hook 0-255.
+		unsigned int xSize, ySize;//Size of the box hook.
+		BoxTrans transparency;//Type of transparency.
 
-			//Returns the color of the box hook.
-			unsigned int GetColor();
+	public:
+		//Boxhook Initaliztors, one for basic hooks and one for groups.
+		Boxhook(HookVisibility visiblity, unsigned int x, unsigned int y, unsigned int xSize, unsigned int ySize);
+		Boxhook(HookGroup* group, unsigned int x, unsigned int y, unsigned int xSize, unsigned int ySize);
 
-			//Sets the color of the box hook.
-			void SetColor(unsigned int newColor);
+		//Returns the color of the box hook.
+		unsigned int GetColor();
 
-
-			//Get the size of the box hook.
-			unsigned int GetXSize();
-
-			//Set the size of the x hook.
-			void SetXSize(unsigned int newX);
+		//Sets the color of the box hook.
+		void SetColor(unsigned int newColor);
 
 
-			//Get the height of the box hook.
-			unsigned int GetYSize();
+		//Get the size of the box hook.
+		unsigned int GetXSize();
 
-			//Set the height of the box hook.
-			void SetYSize(unsigned int newY);
+		//Set the size of the x hook.
+		void SetXSize(unsigned int newX);
 
 
-			//Returns the type of transparency used.
-			BoxTrans GetTransparency();
+		//Get the height of the box hook.
+		unsigned int GetYSize();
 
-			//Set the box transparency.
-			void SetTransparency(BoxTrans trans);
+		//Set the height of the box hook.
+		void SetYSize(unsigned int newY);
 
-			//Draw the text.
-			void OnDraw();
 
-			//Checks if we've been clicked on and calls the handler if so.
-			bool OnLeftClick(bool up, unsigned int x, unsigned int y);
+		//Returns the type of transparency used.
+		BoxTrans GetTransparency();
 
-			//Checks if we've been clicked on and calls the handler if so.
-			bool OnRightClick(bool up, unsigned int x, unsigned int y);
+		//Set the box transparency.
+		void SetTransparency(BoxTrans trans);
 
-			//Static box draw
-			static bool Draw(unsigned int x, unsigned int y, unsigned int xSize, unsigned int ySize, unsigned int color, BoxTrans trans);
-	};
+		//Draw the text.
+		void OnDraw();
+
+		//Checks if we've been clicked on and calls the handler if so.
+		bool OnLeftClick(bool up, unsigned int x, unsigned int y);
+
+		//Checks if we've been clicked on and calls the handler if so.
+		bool OnRightClick(bool up, unsigned int x, unsigned int y);
+
+		//Static box draw
+		static bool Draw(unsigned int x, unsigned int y, unsigned int xSize, unsigned int ySize, unsigned int color, BoxTrans trans);
 };
+
+}  // namespace Drawing

--- a/BH/Drawing/Basic/Crosshook/Crosshook.cpp
+++ b/BH/Drawing/Basic/Crosshook/Crosshook.cpp
@@ -2,7 +2,7 @@
 #include "../../../Common.h"
 #include "../../../D2Ptrs.h"
 
-using namespace Drawing;
+namespace Drawing {
 
 /* Basic Hook Initializer
  *		Used for just drawing basic crosses of screen.
@@ -67,3 +67,5 @@ bool Crosshook::Draw(unsigned int x, unsigned int y, unsigned int color) {
 		D2GFX_DrawLine(x + szLines[n][0], y + szLines[n][1], x + szLines[n+1][0], y + szLines[n+1][1], color, -1);
 	return true;
 }
+
+}  // namespace Drawing

--- a/BH/Drawing/Basic/Framehook/Framehook.cpp
+++ b/BH/Drawing/Basic/Framehook/Framehook.cpp
@@ -2,7 +2,7 @@
 #include "../../../Common.h"
 #include "../../../D2Ptrs.h"
 
-using namespace Drawing;
+namespace Drawing {
 
 /* Basic Hook Initializer
  *		Used for just drawing basic framees on screen.
@@ -150,3 +150,5 @@ bool Framehook::Draw(unsigned int x, unsigned int y, unsigned int xSize, unsigne
 	Framehook::DrawRectStub(&pRect);
 	return true;
 }
+
+}  // namespace Drawing

--- a/BH/Drawing/Basic/Framehook/Framehook.h
+++ b/BH/Drawing/Basic/Framehook/Framehook.h
@@ -3,57 +3,59 @@
 #include "../../Hook.h"
 
 namespace Drawing {
-	class Framehook : public Hook {
-		private:
-			unsigned int color;//Color of the frame hook 0-255.
-			unsigned int xSize, ySize;//Size of the frame hook.
-			BoxTrans transparency;//Type of transparency.
 
-		public:
-			//Framehook Initaliztors, one for basic hooks and one for groups.
-			Framehook(HookVisibility visiblity, unsigned int x, unsigned int y, unsigned int xSize, unsigned int ySize);
-			Framehook(HookGroup* group, unsigned int x, unsigned int y, unsigned int xSize, unsigned int ySize);
+class Framehook : public Hook {
+	private:
+		unsigned int color;//Color of the frame hook 0-255.
+		unsigned int xSize, ySize;//Size of the frame hook.
+		BoxTrans transparency;//Type of transparency.
 
-			//Returns the color of the frame hook.
-			unsigned int GetColor();
+	public:
+		//Framehook Initaliztors, one for basic hooks and one for groups.
+		Framehook(HookVisibility visiblity, unsigned int x, unsigned int y, unsigned int xSize, unsigned int ySize);
+		Framehook(HookGroup* group, unsigned int x, unsigned int y, unsigned int xSize, unsigned int ySize);
 
-			//Sets the color of the frame hook.
-			void SetColor(unsigned int newColor);
+		//Returns the color of the frame hook.
+		unsigned int GetColor();
 
-
-			//Get the size of the frame hook.
-			unsigned int GetXSize();
-
-			//Set the size of the x hook.
-			void SetXSize(unsigned int newX);
+		//Sets the color of the frame hook.
+		void SetColor(unsigned int newColor);
 
 
-			//Get the height of the frame hook.
-			unsigned int GetYSize();
+		//Get the size of the frame hook.
+		unsigned int GetXSize();
 
-			//Set the height of the frame hook.
-			void SetYSize(unsigned int newY);
+		//Set the size of the x hook.
+		void SetXSize(unsigned int newX);
 
 
-			//Returns the type of transparency used.
-			BoxTrans GetTransparency();
+		//Get the height of the frame hook.
+		unsigned int GetYSize();
 
-			//Set the frame transparency.
-			void SetTransparency(BoxTrans trans);
+		//Set the height of the frame hook.
+		void SetYSize(unsigned int newY);
 
-			//ASM Stub to move eax to ecx.
-			static DWORD _fastcall Framehook::DrawRectStub(RECT *pRect);
 
-			//Draw the text.
-			void OnDraw();
+		//Returns the type of transparency used.
+		BoxTrans GetTransparency();
 
-			//Checks if we've been clicked on and calls the handler if so.
-			bool OnLeftClick(bool up, unsigned int x, unsigned int y);
+		//Set the frame transparency.
+		void SetTransparency(BoxTrans trans);
 
-			//Checks if we've been clicked on and calls the handler if so.
-			bool OnRightClick(bool up, unsigned int x, unsigned int y);
+		//ASM Stub to move eax to ecx.
+		static DWORD _fastcall Framehook::DrawRectStub(RECT *pRect);
 
-			//Static Draw Function
-			static bool Draw(unsigned int x, unsigned int y, unsigned int xSize, unsigned int ySize, unsigned int color, BoxTrans trans);
-	};
+		//Draw the text.
+		void OnDraw();
+
+		//Checks if we've been clicked on and calls the handler if so.
+		bool OnLeftClick(bool up, unsigned int x, unsigned int y);
+
+		//Checks if we've been clicked on and calls the handler if so.
+		bool OnRightClick(bool up, unsigned int x, unsigned int y);
+
+		//Static Draw Function
+		static bool Draw(unsigned int x, unsigned int y, unsigned int xSize, unsigned int ySize, unsigned int color, BoxTrans trans);
 };
+
+}  // namespace Drawing

--- a/BH/Drawing/Basic/Linehook/Linehook.cpp
+++ b/BH/Drawing/Basic/Linehook/Linehook.cpp
@@ -2,7 +2,7 @@
 #include "../../../Common.h"
 #include "../../../D2Ptrs.h"
 
-using namespace Drawing;
+namespace Drawing {
 
 /* Basic Hook Initializer
  *		Used for just drawing basic lines of screen.
@@ -99,3 +99,5 @@ bool Linehook::Draw(unsigned int x, unsigned int y, unsigned int x2, unsigned in
 	D2GFX_DrawLine(x,y,x2,y2,color,-1);
 	return true;
 }
+
+}  // namespace Drawing

--- a/BH/Drawing/Basic/Linehook/Linehook.h
+++ b/BH/Drawing/Basic/Linehook/Linehook.h
@@ -3,43 +3,45 @@
 #include "../../Hook.h"
 
 namespace Drawing {
-	class Linehook : public Hook {
-		private:
-			unsigned int color;//Color of the line hook 0-255.
-			unsigned int x2, y2;//2 of the line hook.
 
-		public:
-			//Linehook Initaliztors, one for basic hooks and one for groups.
-			Linehook(HookVisibility visiblity, unsigned int x, unsigned int y, unsigned int x2, unsigned int y2);
-			Linehook(HookGroup* group, unsigned int x, unsigned int y, unsigned int x2, unsigned int y2);
+class Linehook : public Hook {
+	private:
+		unsigned int color;//Color of the line hook 0-255.
+		unsigned int x2, y2;//2 of the line hook.
 
-			//Returns the color of the line hook.
-			unsigned int GetColor();
+	public:
+		//Linehook Initaliztors, one for basic hooks and one for groups.
+		Linehook(HookVisibility visiblity, unsigned int x, unsigned int y, unsigned int x2, unsigned int y2);
+		Linehook(HookGroup* group, unsigned int x, unsigned int y, unsigned int x2, unsigned int y2);
 
-			//Sets the color of the line hook.
-			void SetColor(unsigned int newColor);
+		//Returns the color of the line hook.
+		unsigned int GetColor();
+
+		//Sets the color of the line hook.
+		void SetColor(unsigned int newColor);
 
 
-			//Get the size of the line hook.
-			unsigned int GetX2();
+		//Get the size of the line hook.
+		unsigned int GetX2();
 
-			//Set the size of the x hook.
-			void SetX2(unsigned int newX);
+		//Set the size of the x hook.
+		void SetX2(unsigned int newX);
 
-			//Filler to return nothing to base class.
-			unsigned int GetXSize();
-			unsigned int GetYSize();
+		//Filler to return nothing to base class.
+		unsigned int GetXSize();
+		unsigned int GetYSize();
 
-			//Get the height of the line hook.
-			unsigned int GetY2();
+		//Get the height of the line hook.
+		unsigned int GetY2();
 
-			//Set the height of the line hook.
-			void SetY2(unsigned int newY);
+		//Set the height of the line hook.
+		void SetY2(unsigned int newY);
 
-			//Draw the text.
-			void OnDraw();
+		//Draw the text.
+		void OnDraw();
 
-			//Static line draw
-			static bool Draw(unsigned int x, unsigned int y, unsigned int x2, unsigned int y2, unsigned int color);
-	};
+		//Static line draw
+		static bool Draw(unsigned int x, unsigned int y, unsigned int x2, unsigned int y2, unsigned int color);
 };
+
+}  // namespace Drawing

--- a/BH/Drawing/Basic/Texthook/Texthook.cpp
+++ b/BH/Drawing/Basic/Texthook/Texthook.cpp
@@ -2,7 +2,7 @@
 #include "../../../Common.h"
 #include "../../../D2Ptrs.h"
 
-using namespace Drawing;
+namespace Drawing {
 
 /* Basic Hook Initializer
  *		Used for just drawing basic text on screen.
@@ -255,3 +255,5 @@ bool Texthook::Draw(unsigned int x, unsigned int y, int align, unsigned int font
 	delete[] buffer;
 	return true;
 }
+
+}  // namespace Drawing

--- a/BH/Drawing/Basic/Texthook/Texthook.h
+++ b/BH/Drawing/Basic/Texthook/Texthook.h
@@ -4,64 +4,66 @@
 #include <string>
 
 namespace Drawing {
-	class Texthook : public Hook {
-		private:
-			std::string text;//Text to be drawn.
-			unsigned int font;//Determines which built-in diablo font to use.
-			TextColor color, hoverColor;//Determines which color to use.
-		public:
-			//Two Hook Initializations; one for basic hooks, one for grouped hooks.
-			Texthook(HookVisibility visibility, unsigned int x, unsigned int y, std::string formatString, ...);
-			Texthook(HookGroup* group, unsigned int x, unsigned int y, std::string formatString, ...);
 
-			//Returns what D2 Font we are drawing with.
-			unsigned int GetFont();
+class Texthook : public Hook {
+	private:
+		std::string text;//Text to be drawn.
+		unsigned int font;//Determines which built-in diablo font to use.
+		TextColor color, hoverColor;//Determines which color to use.
+	public:
+		//Two Hook Initializations; one for basic hooks, one for grouped hooks.
+		Texthook(HookVisibility visibility, unsigned int x, unsigned int y, std::string formatString, ...);
+		Texthook(HookGroup* group, unsigned int x, unsigned int y, std::string formatString, ...);
 
-			//Sets what D2 Font to draw with
-			void SetFont(unsigned int newFont);
+		//Returns what D2 Font we are drawing with.
+		unsigned int GetFont();
 
-		
-			//Returns what D2 Color we are drawing with.
-			TextColor GetColor();
+		//Sets what D2 Font to draw with
+		void SetFont(unsigned int newFont);
 
-			//Sets what D2 Color we are drawing with.
-			void SetColor(TextColor newColor);
+	
+		//Returns what D2 Color we are drawing with.
+		TextColor GetColor();
 
-
-			//Returns what D2 Color we want when mouse is hovering over text, default is disabled.
-			TextColor GetHoverColor();
-
-			//Set what D2 Color we should draw with when hovered.
-			void SetHoverColor(TextColor newHoverColor);
+		//Sets what D2 Color we are drawing with.
+		void SetColor(TextColor newColor);
 
 
-			//Returns what text we are drawing
-			std::string GetText();
+		//Returns what D2 Color we want when mouse is hovering over text, default is disabled.
+		TextColor GetHoverColor();
 
-			//Set what text you want drawn
-			void SetText(std::string formatString, ...);
+		//Set what D2 Color we should draw with when hovered.
+		void SetHoverColor(TextColor newHoverColor);
 
-			//Determine the pixel length of the text.
-			unsigned int GetXSize();
 
-			//Determine the pixel height of the text.
-			unsigned int GetYSize();
+		//Returns what text we are drawing
+		std::string GetText();
 
-			//Draw the text.
-			void OnDraw();
+		//Set what text you want drawn
+		void SetText(std::string formatString, ...);
 
-			//Checks if we've been clicked on and calls the handler if so.
-			bool OnLeftClick(bool up, unsigned int x, unsigned int y);
+		//Determine the pixel length of the text.
+		unsigned int GetXSize();
 
-			//Checks if we've been clicked on and calls the handler if so.
-			bool OnRightClick(bool up, unsigned int x, unsigned int y);
+		//Determine the pixel height of the text.
+		unsigned int GetYSize();
 
-			//Handy function to have!
-			static POINT GetTextSize(std::string text, unsigned int font);
-			static POINT GetTextSize(wchar_t* text, unsigned int font);
+		//Draw the text.
+		void OnDraw();
 
-			//Static draw text function
-			static bool Draw(unsigned int x, unsigned int y, int align, unsigned int font, TextColor color, std::string text, ...);
-			static bool Draw(unsigned int x, unsigned int y, int align, unsigned int font, TextColor color, wchar_t* text, ...);
-	};
+		//Checks if we've been clicked on and calls the handler if so.
+		bool OnLeftClick(bool up, unsigned int x, unsigned int y);
+
+		//Checks if we've been clicked on and calls the handler if so.
+		bool OnRightClick(bool up, unsigned int x, unsigned int y);
+
+		//Handy function to have!
+		static POINT GetTextSize(std::string text, unsigned int font);
+		static POINT GetTextSize(wchar_t* text, unsigned int font);
+
+		//Static draw text function
+		static bool Draw(unsigned int x, unsigned int y, int align, unsigned int font, TextColor color, std::string text, ...);
+		static bool Draw(unsigned int x, unsigned int y, int align, unsigned int font, TextColor color, wchar_t* text, ...);
 };
+
+}  // namespace Drawing

--- a/BH/Drawing/Hook.cpp
+++ b/BH/Drawing/Hook.cpp
@@ -2,7 +2,7 @@
 #include "Advanced/Colorhook/Colorhook.h"
 #include "../D2Ptrs.h"
 
-using namespace Drawing;
+namespace Drawing {
 
 std::list<Hook*> Hook::Hooks;
 
@@ -370,3 +370,5 @@ bool Hook::KeyClick(bool bUp, BYTE bKey, LPARAM lParam) {
 				block = true;
 	return block;
 }
+
+}  // namespace Drawing

--- a/BH/Drawing/Hook.h
+++ b/BH/Drawing/Hook.h
@@ -4,158 +4,160 @@
 #include <string>
 
 namespace Drawing {
-	// HookGroups allow use of the basic hooks(Line,Text,Box,Frame)
-	//	in more advanced hooks(Input,UI,Button) that require
-	//	multiple basic hooks.
-	class Hook;
-	class HookGroup {
-		public:
-			std::list<Hook*> Hooks;
-			virtual unsigned int GetX() = 0;
-			virtual unsigned int GetY() = 0;
-			virtual unsigned int GetXSize() = 0;
-			virtual unsigned int GetYSize() = 0;
-			virtual bool IsActive() = 0;
-	};
 
-	enum HookVisibility {InGame,OutOfGame,Automap,Perm,Group};
-	enum BoxTrans {BTThreeFourths, BTOneHalf, BTOneFourth, BTWhite, BTBlack, BTNormal, BTScreen, BTHighlight, BTFull};
-	enum {None=0, Center=1, Right=2, Top=4};
-
-
-	typedef std::list<Hook*> HookList;
-	typedef std::list<Hook*>::iterator HookIterator;
-	typedef bool (__cdecl *OnClick)(bool,Hook*,void*);
-
-	class Hook {
-		private:
-			static HookList Hooks;//Holds a list of every basic hook used.
-			HookVisibility visibility;//When we should show the hook.
-			unsigned int x, y, z;//Hooks screen coordinates and the z-order.
-			CRITICAL_SECTION crit;//Critical Section so we don't have race conditions.
-			bool active;//Boolean to hold if we should draw the hook or not.
-			int alignment;//Holds what type of alignment(if any) we should use.
-			HookGroup* group;//Holds the group this hook is associated with.
-			OnClick left;//Click callback handler for left clicking
-			void* leftVoid;//Holds data to give back to the callback for things like knowing your proper class.
-			OnClick right;//Click callback handler for right clicking
-			void* rightVoid;//Holds data to give back to the callback for things like knowing your proper class.
-		public:
-			//Two Hook Initializations; one for basic hooks, one for grouped hooks.
-			Hook(HookVisibility visibility, unsigned int x, unsigned int y);
-			Hook(HookGroup* group, unsigned int x, unsigned int y);
-			//~Hook();
-
-			//Critical Section Helpers.
-			void Lock();
-			void Unlock();
-
-			//Returns the x position of where the hook will be drawn.
-			unsigned int GetX();
-
-			//Returns the base x position not calculating in groups or alignment.
-			unsigned int GetBaseX();
-
-			//Sets the base x position, or offset from groups x position.
-			void SetBaseX(unsigned int xPos);
-
-			//Returns the width of the hook, determine by super-class.
-			virtual unsigned int GetXSize() = 0;
-
-
-			//Returns the y position of where the hook will be drawn.
-			unsigned int GetY();
-
-			//Returns the base y position not calculating in groups or alignment.
-			unsigned int GetBaseY();
-
-			//Sets the base y position, or offset from groups y position.
-			void SetBaseY(unsigned int yPos);
-
-			//Returns the height of the hook, determine by super-class.
-			virtual unsigned int GetYSize() = 0;
-
-
-			//Returns when the hook will be drawn compared to other hooks.
-			int GetZOrder();
-
-			//Sets when the hook will be drawn compared to the other hooks.
-			void SetZOrder(int zPos);
-
-
-			//Returns when the hook will be visible
-			HookVisibility GetVisibility();
-
-			//Sets when the hook will be visible
-			void SetVisibility(HookVisibility newVisibility);
-
-
-			//Returns if we are drawing the hook currently.
-			bool IsActive();
-
-			//Sets if we should be drawing the hook.
-			void SetActive(bool newActive);
-
-
-			//Returns how we are going to align the hook.
-			int GetAlignment();
-
-			//Sets how we are to align the hook.
-			void SetAlignment(int newAlign);
-
-			
-			//Returns the hook's group.
-			HookGroup* GetGroup();
-
-			//Sets the hook's group.
-			void SetGroup(HookGroup* newGroup);
-
-			//Returns the callback handler for left clicks
-			OnClick GetLeftClickHandler();
-
-			//Return the callback void handler for left clicks
-			void* GetLeftClickVoid();
-
-			//Set the callback for left clicks
-			void SetLeftCallback(OnClick leftHandler, void* voidVar);
-
-
-			//Returns the callback handler for right clicks
-			OnClick GetRightClickHandler();
-
-			//Return the callback void handler for right clicks
-			void* GetRightClickVoid();
-
-			//Set the callback for right clicks
-			void SetRightCallback(OnClick rightHandler, void* voidVar);
-
-			//Determine if the given x/y set is within the hooks drawing area.
-			bool InRange(unsigned int x, unsigned int y);
-
-			//This is the function in super-class we actually draw the function.
-			virtual void OnDraw() = 0;
-
-			//Function gets called when someone clicks, return true to block the click.
-			virtual bool OnLeftClick(bool up, unsigned int x, unsigned int y) { return false; };
-			virtual bool OnRightClick(bool up, unsigned int x, unsigned int y) { return false; };
-
-			//Function gets called when someone types, return true to block the input.
-			virtual bool OnKey(bool up, BYTE key, LPARAM lParam) { return false; };
-
-
-			//Static function to draw all the hooks with the given visibility.
-			static void Draw(HookVisibility type);
-
-			//Static function to check if we interacted with any hooks.
-			static bool LeftClick(bool up, unsigned int x, unsigned int y);
-			static bool RightClick(bool up, unsigned int x, unsigned int y);
-			static bool KeyClick(bool bUp, BYTE bKey, LPARAM lParam);
-
-			//Misc Hook Functions needed
-			static unsigned int GetScreenHeight();
-			static unsigned int GetScreenWidth();
-			static void ScreenToAutomap(POINT* ptPos, int x, int y);
-			static void AutomapToScreen(POINT* ptPos, int x, int y);
-
-	};
+// HookGroups allow use of the basic hooks(Line,Text,Box,Frame)
+//	in more advanced hooks(Input,UI,Button) that require
+//	multiple basic hooks.
+class Hook;
+class HookGroup {
+	public:
+		std::list<Hook*> Hooks;
+		virtual unsigned int GetX() = 0;
+		virtual unsigned int GetY() = 0;
+		virtual unsigned int GetXSize() = 0;
+		virtual unsigned int GetYSize() = 0;
+		virtual bool IsActive() = 0;
 };
+
+enum HookVisibility {InGame,OutOfGame,Automap,Perm,Group};
+enum BoxTrans {BTThreeFourths, BTOneHalf, BTOneFourth, BTWhite, BTBlack, BTNormal, BTScreen, BTHighlight, BTFull};
+enum {None=0, Center=1, Right=2, Top=4};
+
+
+typedef std::list<Hook*> HookList;
+typedef std::list<Hook*>::iterator HookIterator;
+typedef bool (__cdecl *OnClick)(bool,Hook*,void*);
+
+class Hook {
+	private:
+		static HookList Hooks;//Holds a list of every basic hook used.
+		HookVisibility visibility;//When we should show the hook.
+		unsigned int x, y, z;//Hooks screen coordinates and the z-order.
+		CRITICAL_SECTION crit;//Critical Section so we don't have race conditions.
+		bool active;//Boolean to hold if we should draw the hook or not.
+		int alignment;//Holds what type of alignment(if any) we should use.
+		HookGroup* group;//Holds the group this hook is associated with.
+		OnClick left;//Click callback handler for left clicking
+		void* leftVoid;//Holds data to give back to the callback for things like knowing your proper class.
+		OnClick right;//Click callback handler for right clicking
+		void* rightVoid;//Holds data to give back to the callback for things like knowing your proper class.
+	public:
+		//Two Hook Initializations; one for basic hooks, one for grouped hooks.
+		Hook(HookVisibility visibility, unsigned int x, unsigned int y);
+		Hook(HookGroup* group, unsigned int x, unsigned int y);
+		//~Hook();
+
+		//Critical Section Helpers.
+		void Lock();
+		void Unlock();
+
+		//Returns the x position of where the hook will be drawn.
+		unsigned int GetX();
+
+		//Returns the base x position not calculating in groups or alignment.
+		unsigned int GetBaseX();
+
+		//Sets the base x position, or offset from groups x position.
+		void SetBaseX(unsigned int xPos);
+
+		//Returns the width of the hook, determine by super-class.
+		virtual unsigned int GetXSize() = 0;
+
+
+		//Returns the y position of where the hook will be drawn.
+		unsigned int GetY();
+
+		//Returns the base y position not calculating in groups or alignment.
+		unsigned int GetBaseY();
+
+		//Sets the base y position, or offset from groups y position.
+		void SetBaseY(unsigned int yPos);
+
+		//Returns the height of the hook, determine by super-class.
+		virtual unsigned int GetYSize() = 0;
+
+
+		//Returns when the hook will be drawn compared to other hooks.
+		int GetZOrder();
+
+		//Sets when the hook will be drawn compared to the other hooks.
+		void SetZOrder(int zPos);
+
+
+		//Returns when the hook will be visible
+		HookVisibility GetVisibility();
+
+		//Sets when the hook will be visible
+		void SetVisibility(HookVisibility newVisibility);
+
+
+		//Returns if we are drawing the hook currently.
+		bool IsActive();
+
+		//Sets if we should be drawing the hook.
+		void SetActive(bool newActive);
+
+
+		//Returns how we are going to align the hook.
+		int GetAlignment();
+
+		//Sets how we are to align the hook.
+		void SetAlignment(int newAlign);
+
+		
+		//Returns the hook's group.
+		HookGroup* GetGroup();
+
+		//Sets the hook's group.
+		void SetGroup(HookGroup* newGroup);
+
+		//Returns the callback handler for left clicks
+		OnClick GetLeftClickHandler();
+
+		//Return the callback void handler for left clicks
+		void* GetLeftClickVoid();
+
+		//Set the callback for left clicks
+		void SetLeftCallback(OnClick leftHandler, void* voidVar);
+
+
+		//Returns the callback handler for right clicks
+		OnClick GetRightClickHandler();
+
+		//Return the callback void handler for right clicks
+		void* GetRightClickVoid();
+
+		//Set the callback for right clicks
+		void SetRightCallback(OnClick rightHandler, void* voidVar);
+
+		//Determine if the given x/y set is within the hooks drawing area.
+		bool InRange(unsigned int x, unsigned int y);
+
+		//This is the function in super-class we actually draw the function.
+		virtual void OnDraw() = 0;
+
+		//Function gets called when someone clicks, return true to block the click.
+		virtual bool OnLeftClick(bool up, unsigned int x, unsigned int y) { return false; };
+		virtual bool OnRightClick(bool up, unsigned int x, unsigned int y) { return false; };
+
+		//Function gets called when someone types, return true to block the input.
+		virtual bool OnKey(bool up, BYTE key, LPARAM lParam) { return false; };
+
+
+		//Static function to draw all the hooks with the given visibility.
+		static void Draw(HookVisibility type);
+
+		//Static function to check if we interacted with any hooks.
+		static bool LeftClick(bool up, unsigned int x, unsigned int y);
+		static bool RightClick(bool up, unsigned int x, unsigned int y);
+		static bool KeyClick(bool bUp, BYTE bKey, LPARAM lParam);
+
+		//Misc Hook Functions needed
+		static unsigned int GetScreenHeight();
+		static unsigned int GetScreenWidth();
+		static void ScreenToAutomap(POINT* ptPos, int x, int y);
+		static void AutomapToScreen(POINT* ptPos, int x, int y);
+
+};
+
+}  // namespace Drawing

--- a/BH/Drawing/Stats/StatsDisplay.cpp
+++ b/BH/Drawing/Stats/StatsDisplay.cpp
@@ -13,7 +13,7 @@ using ::common::str_util::Trim;
 
 }  // namespace
 
-using namespace Drawing;
+namespace Drawing {
 
 StatsDisplay *StatsDisplay::display;
 
@@ -424,3 +424,5 @@ bool StatsDisplay::OnClick(bool up, unsigned int x, unsigned int y) {
 	}
 	return false;
 }
+
+}  // namespace Drawing

--- a/BH/Drawing/Stats/StatsDisplay.h
+++ b/BH/Drawing/Stats/StatsDisplay.h
@@ -16,52 +16,54 @@ struct DisplayedStat {
 };
 
 namespace Drawing {
-	class StatsDisplay;
 
-	class StatsDisplay : public HookGroup {
-		private:
-			std::map<std::string, Toggle> Toggles;
-			static StatsDisplay *display;
-			std::string name;
-			unsigned int x, y, xSize, ySize;
-			unsigned int statsKey;
-			bool active, minimized;
-			CRITICAL_SECTION crit;
-			std::vector<DisplayedStat*> customStats;
-		public:
-			StatsDisplay(std::string name);
-			~StatsDisplay();
+class StatsDisplay;
 
-			void LoadConfig();
+class StatsDisplay : public HookGroup {
+	private:
+		std::map<std::string, Toggle> Toggles;
+		static StatsDisplay *display;
+		std::string name;
+		unsigned int x, y, xSize, ySize;
+		unsigned int statsKey;
+		bool active, minimized;
+		CRITICAL_SECTION crit;
+		std::vector<DisplayedStat*> customStats;
+	public:
+		StatsDisplay(std::string name);
+		~StatsDisplay();
 
-			void Lock() { EnterCriticalSection(&crit); };
-			void Unlock() { LeaveCriticalSection(&crit); };
+		void LoadConfig();
 
-			std::string GetName() { return name; };
-			unsigned int GetX() { return x; };
-			unsigned int GetY() { return y; };
-			unsigned int GetXSize() { return xSize; };
-			unsigned int GetYSize() { return ySize; };
-			bool IsActive() { return active; };
-			bool IsMinimized() { return minimized; };
+		void Lock() { EnterCriticalSection(&crit); };
+		void Unlock() { LeaveCriticalSection(&crit); };
 
-			bool InRange(unsigned int x, unsigned int y);
+		std::string GetName() { return name; };
+		unsigned int GetX() { return x; };
+		unsigned int GetY() { return y; };
+		unsigned int GetXSize() { return xSize; };
+		unsigned int GetYSize() { return ySize; };
+		bool IsActive() { return active; };
+		bool IsMinimized() { return minimized; };
 
-			void SetX(unsigned int newX);
-			void SetY(unsigned int newY);
-			void SetXSize(unsigned int newXSize);
-			void SetYSize(unsigned int newYSize);
-			void SetName(std::string newName) { Lock(); name = newName;  Unlock(); };
-			void SetActive(bool newState) { Lock(); active = newState; Unlock(); };
-			void SetMinimized(bool newState) { Lock(); minimized = newState; Unlock(); };
+		bool InRange(unsigned int x, unsigned int y);
 
-			void OnDraw();
-			static void Draw();
+		void SetX(unsigned int newX);
+		void SetY(unsigned int newY);
+		void SetXSize(unsigned int newXSize);
+		void SetYSize(unsigned int newYSize);
+		void SetName(std::string newName) { Lock(); name = newName;  Unlock(); };
+		void SetActive(bool newState) { Lock(); active = newState; Unlock(); };
+		void SetMinimized(bool newState) { Lock(); minimized = newState; Unlock(); };
 
-			bool OnClick(bool up, unsigned int mouseX, unsigned int mouseY);
-			static bool Click(bool up, unsigned int mouseX, unsigned int mouseY);
+		void OnDraw();
+		static void Draw();
 
-			bool OnKey(bool up, BYTE key, LPARAM lParam);
-			static bool KeyClick(bool bUp, BYTE bKey, LPARAM lParam);
-	};
+		bool OnClick(bool up, unsigned int mouseX, unsigned int mouseY);
+		static bool Click(bool up, unsigned int mouseX, unsigned int mouseY);
+
+		bool OnKey(bool up, BYTE key, LPARAM lParam);
+		static bool KeyClick(bool bUp, BYTE bKey, LPARAM lParam);
 };
+
+}  // namespace Drawing

--- a/BH/Drawing/UI/UI.cpp
+++ b/BH/Drawing/UI/UI.cpp
@@ -5,7 +5,7 @@
 #include "../Basic/Texthook/Texthook.h"
 #include "../Basic/Framehook/Framehook.h"
 
-using namespace Drawing;
+namespace Drawing {
 
 std::list<UI*> UI::UIs;
 std::list<UI*> UI::Minimized;
@@ -382,3 +382,5 @@ bool UI::RightClick(bool up, unsigned int mouseX, unsigned int mouseY) {
 	}
 	return false;
 }
+
+}  // namespace Drawing

--- a/BH/Drawing/UI/UI.h
+++ b/BH/Drawing/UI/UI.h
@@ -6,79 +6,81 @@
 #include "../Hook.h"
 
 namespace Drawing {
-	class UI;
-	class UITab;
 
-	#define TITLE_BAR_HEIGHT 15
-	#define MINIMIZED_Y_POS 585
-	#define MINIMIZED_X_POS 234
+class UI;
+class UITab;
 
-	class UI : public HookGroup {
-		private:
-			static std::list<UI*> UIs;
-			static std::list<UI*> Minimized;
-			unsigned int x, y, xSize, ySize, zOrder;//Position and Size and Order
-			unsigned int minimizedX, minimizedY;//Position when minimized
-			bool active, minimized, dragged, visible;//If UI is active or minimized or dragged
-			unsigned int dragX, dragY;//Position where we grabbed it.
-			unsigned int startX, startY;//Position where we grabbed it.
-			std::string name;//Name of the UI
-			UITab* currentTab;//Current tab open at the time.
-			CRITICAL_SECTION crit;//Critical section
+#define TITLE_BAR_HEIGHT 15
+#define MINIMIZED_Y_POS 585
+#define MINIMIZED_X_POS 234
 
-			void EnsureInBounds();
-		public:
-			std::list<UITab*> Tabs;
+class UI : public HookGroup {
+	private:
+		static std::list<UI*> UIs;
+		static std::list<UI*> Minimized;
+		unsigned int x, y, xSize, ySize, zOrder;//Position and Size and Order
+		unsigned int minimizedX, minimizedY;//Position when minimized
+		bool active, minimized, dragged, visible;//If UI is active or minimized or dragged
+		unsigned int dragX, dragY;//Position where we grabbed it.
+		unsigned int startX, startY;//Position where we grabbed it.
+		std::string name;//Name of the UI
+		UITab* currentTab;//Current tab open at the time.
+		CRITICAL_SECTION crit;//Critical section
 
-			UI(std::string name, unsigned int xSize, unsigned int ySize);
-			~UI();
+		void EnsureInBounds();
+	public:
+		std::list<UITab*> Tabs;
 
-			void Lock() { EnterCriticalSection(&crit); };
-			void Unlock() { LeaveCriticalSection(&crit); };
+		UI(std::string name, unsigned int xSize, unsigned int ySize);
+		~UI();
 
-			unsigned int GetX() { return x; };
-			unsigned int GetY() { return y; };
-			unsigned int GetXSize() { return xSize; };
-			unsigned int GetYSize() { return ySize; };
-			unsigned int GetMinimizedX() { return minimizedX; };
-			unsigned int GetMinimizedY() { return minimizedY; };
-			bool IsActive() { return active; };
-			bool IsMinimized() { return minimized; };
-			bool IsDragged() { return dragged; };
-			bool IsVisible() { return visible; };
-			std::string GetName() { return name; };
-			unsigned int GetZOrder() { return zOrder; };
+		void Lock() { EnterCriticalSection(&crit); };
+		void Unlock() { LeaveCriticalSection(&crit); };
 
-			void SetX(unsigned int newX);
-			void SetY(unsigned int newY);
-			void SetXSize(unsigned int newXSize);
-			void SetYSize(unsigned int newYSize);
-			void SetMinimizedX(unsigned int newX);
-			void SetMinimizedY(unsigned int newY);
-			void SetActive(bool newState) { Lock(); active = newState; Unlock(); };
-			void SetMinimized(bool newState);
-			void SetVisible(bool newState);
-			void SetName(std::string newName) { Lock(); name = newName;  Unlock(); };
-			void SetDragged(bool state, bool write_file); // only write config to file if write_file is true
-			void SetDragged(bool state); // never writes the config file
-			void SetZOrder(unsigned int newZ) { Lock(); zOrder = newZ; Unlock(); };
+		unsigned int GetX() { return x; };
+		unsigned int GetY() { return y; };
+		unsigned int GetXSize() { return xSize; };
+		unsigned int GetYSize() { return ySize; };
+		unsigned int GetMinimizedX() { return minimizedX; };
+		unsigned int GetMinimizedY() { return minimizedY; };
+		bool IsActive() { return active; };
+		bool IsMinimized() { return minimized; };
+		bool IsDragged() { return dragged; };
+		bool IsVisible() { return visible; };
+		std::string GetName() { return name; };
+		unsigned int GetZOrder() { return zOrder; };
 
-			UITab* GetActiveTab() { if (!currentTab) { currentTab = (*Tabs.begin()); } return currentTab; };
-			void SetCurrentTab(UITab* tab) { Lock(); currentTab = tab; Unlock(); };
+		void SetX(unsigned int newX);
+		void SetY(unsigned int newY);
+		void SetXSize(unsigned int newXSize);
+		void SetYSize(unsigned int newYSize);
+		void SetMinimizedX(unsigned int newX);
+		void SetMinimizedY(unsigned int newY);
+		void SetActive(bool newState) { Lock(); active = newState; Unlock(); };
+		void SetMinimized(bool newState);
+		void SetVisible(bool newState);
+		void SetName(std::string newName) { Lock(); name = newName;  Unlock(); };
+		void SetDragged(bool state, bool write_file); // only write config to file if write_file is true
+		void SetDragged(bool state); // never writes the config file
+		void SetZOrder(unsigned int newZ) { Lock(); zOrder = newZ; Unlock(); };
 
-			void OnDraw();
-			static void Draw();
+		UITab* GetActiveTab() { if (!currentTab) { currentTab = (*Tabs.begin()); } return currentTab; };
+		void SetCurrentTab(UITab* tab) { Lock(); currentTab = tab; Unlock(); };
 
-			static void Sort(UI* zero);
+		void OnDraw();
+		static void Draw();
 
-			bool OnLeftClick(bool up, unsigned int mouseX, unsigned int mouseY);
-			static bool LeftClick(bool up, unsigned int mouseX, unsigned int mouseY);
+		static void Sort(UI* zero);
 
-			bool OnRightClick(bool up, unsigned int mouseX, unsigned int mouseY);
-			static bool RightClick(bool up, unsigned int mouseX, unsigned int mouseY);
+		bool OnLeftClick(bool up, unsigned int mouseX, unsigned int mouseY);
+		static bool LeftClick(bool up, unsigned int mouseX, unsigned int mouseY);
 
-			bool InWindow(unsigned int xPos, unsigned int yPos) { return xPos >= x && xPos <= x + xSize && yPos >= y && yPos <= y + ySize; };
-			bool InTitle(unsigned int xPos, unsigned int yPos) { return xPos >= x && xPos <= x + xSize && yPos >= y && yPos <= y + TITLE_BAR_HEIGHT; };
-			static bool InPos(unsigned int xPos, unsigned int yPos, unsigned int x, unsigned int y, unsigned int xSize, unsigned int ySize) { return xPos >= x && xPos <= x + xSize && yPos >= y && yPos <= y + ySize; };
-	};
+		bool OnRightClick(bool up, unsigned int mouseX, unsigned int mouseY);
+		static bool RightClick(bool up, unsigned int mouseX, unsigned int mouseY);
+
+		bool InWindow(unsigned int xPos, unsigned int yPos) { return xPos >= x && xPos <= x + xSize && yPos >= y && yPos <= y + ySize; };
+		bool InTitle(unsigned int xPos, unsigned int yPos) { return xPos >= x && xPos <= x + xSize && yPos >= y && yPos <= y + TITLE_BAR_HEIGHT; };
+		static bool InPos(unsigned int xPos, unsigned int yPos, unsigned int x, unsigned int y, unsigned int xSize, unsigned int ySize) { return xPos >= x && xPos <= x + xSize && yPos >= y && yPos <= y + ySize; };
 };
+
+}  // namespace Drawing

--- a/BH/Drawing/UI/UITab.cpp
+++ b/BH/Drawing/UI/UITab.cpp
@@ -3,7 +3,7 @@
 #include "../Basic/Framehook/Framehook.h"
 #include "../../D2Ptrs.h"
 
-using namespace Drawing;
+namespace Drawing {
 
 UITab::~UITab() {
 	ui->Lock();
@@ -37,3 +37,5 @@ void UITab::OnDraw() {
 		Framehook::Draw(GetTabX(), GetTabY(), GetTabSize(), TAB_HEIGHT, 0, (ui->IsActive()?BTNormal:BTHighlight));
 	Texthook::Draw(GetTabX() + (GetTabSize() / 2), GetTabY() + 2, Center, 0, IsActive()?Grey:isHovering?Tan:Gold, name);
 }
+
+}  // namespace Drawing

--- a/BH/Drawing/UI/UITab.h
+++ b/BH/Drawing/UI/UITab.h
@@ -3,31 +3,33 @@
 #include "UI.h"
 
 namespace Drawing {
-	#define TAB_HEIGHT 13
 
-	class UITab : public HookGroup {
-		private:
-			std::string name;
-			UI* ui;
-		public:
-			UITab(std::string name, UI* nui) : name(name), ui(nui) {ui->Tabs.push_back(this); if (ui->Tabs.size() == 1) { ui->SetCurrentTab(this); }};
-			~UITab();
+#define TAB_HEIGHT 13
 
-			unsigned int GetX() { return ui->GetX(); };
-			unsigned int GetY() { return ui->GetY() + TITLE_BAR_HEIGHT + TAB_HEIGHT; };
-			unsigned int GetXSize() { return ui->GetXSize(); };
-			unsigned int GetYSize() { return ui->GetYSize() - TITLE_BAR_HEIGHT - TAB_HEIGHT; };
+class UITab : public HookGroup {
+	private:
+		std::string name;
+		UI* ui;
+	public:
+		UITab(std::string name, UI* nui) : name(name), ui(nui) {ui->Tabs.push_back(this); if (ui->Tabs.size() == 1) { ui->SetCurrentTab(this); }};
+		~UITab();
 
-			unsigned int GetTabPos();
-			unsigned int GetTabSize() { return (ui->GetXSize() / ui->Tabs.size()); };
-			unsigned int GetTabX() { return ui->GetX() + GetTabPos() * GetTabSize(); };
-			unsigned int GetTabY() { return ui->GetY() + TITLE_BAR_HEIGHT; };
+		unsigned int GetX() { return ui->GetX(); };
+		unsigned int GetY() { return ui->GetY() + TITLE_BAR_HEIGHT + TAB_HEIGHT; };
+		unsigned int GetXSize() { return ui->GetXSize(); };
+		unsigned int GetYSize() { return ui->GetYSize() - TITLE_BAR_HEIGHT - TAB_HEIGHT; };
+
+		unsigned int GetTabPos();
+		unsigned int GetTabSize() { return (ui->GetXSize() / ui->Tabs.size()); };
+		unsigned int GetTabX() { return ui->GetX() + GetTabPos() * GetTabSize(); };
+		unsigned int GetTabY() { return ui->GetY() + TITLE_BAR_HEIGHT; };
 
 
-			bool IsActive() { return ui->GetActiveTab() == this && !ui->IsMinimized(); };
+		bool IsActive() { return ui->GetActiveTab() == this && !ui->IsMinimized(); };
 
-			bool IsHovering(unsigned int x, unsigned int y) { return x >= GetTabX() && y >= GetTabY() && x <= (GetTabX() + GetTabSize()) && y <= (GetTabY() + TAB_HEIGHT); };
+		bool IsHovering(unsigned int x, unsigned int y) { return x >= GetTabX() && y >= GetTabY() && x <= (GetTabX() + GetTabSize()) && y <= (GetTabY() + TAB_HEIGHT); };
 
-			void OnDraw();
-	};
+		void OnDraw();
 };
+
+}  // namespace Drawing

--- a/BH/Modules/AutoTele/AutoTele.cpp
+++ b/BH/Modules/AutoTele/AutoTele.cpp
@@ -3,19 +3,25 @@
 #include "ATIncludes\CMapIncludes.h"
 #include "ATIncludes\Vectors.h"
 
+namespace {
+
+using ::Drawing::Checkhook;
+using ::Drawing::Colorhook;
+using ::Drawing::Texthook;
+using ::Drawing::UITab;
+
+}  // namespace
+
 #define VALIDPTR(x) ( (x) && (!IsBadReadPtr(x,sizeof(x))) )
 
 int waypoints[] = {119,157,156,323,288,402,324,237,238,398,496,511,494};
 int CSID = 0;
 int CS[] = {392, 394, 396, 255};
 
-
-using namespace Drawing;
-
 void AutoTele::OnLoad() {
 	LoadConfig();
 
-	std::map<std::string, bool>* bnetBools (BH::BnetBools);
+	std::map<std::string, bool>* bnetBools(BH::BnetBools);
 	std::map<std::string, bool>* gamefilterBools(BH::GamefilterBools);
 
 	settingsTab = new UITab("Misc", BH::settingsUI);
@@ -141,7 +147,7 @@ void AutoTele::OnLoop() {
 		if(SetTele) {
 			if(!SetSkill(0x36, 0)) {	//0x36 is teleport
 				TPath.RemoveAll();
-				PrintText(1, "�c4AutoTele:�c1 Failed to set teleport!");
+				PrintText(1, "\xFF" "c4AutoTele:" "\xFF" "c1 Failed to set teleport!");
 			}
 			_timer = GetTickCount();
 			SetTele = 0;
@@ -153,12 +159,12 @@ void AutoTele::OnLoop() {
 			if(TeleActive) {
 				TeleActive = 0;
 				TPath.RemoveAll();
-				PrintText(1, "�c4AutoTele:�c1 Aborting teleport, deselected teleport");
+				PrintText(1, "\xFF" "c4AutoTele:" "\xFF" "c1 Aborting teleport, deselected teleport");
 				return;
 			}
 			if((GetTickCount() - _timer) > 1000) {
 				TPath.RemoveAll();
-				PrintText(1, "�c4AutoTele:�c1 Failed to set teleport skill. Ping: %d", *p_D2CLIENT_Ping);
+				PrintText(1, "\xFF" "c4AutoTele:" "\xFF" "c1 Failed to set teleport skill. Ping: %d", *p_D2CLIENT_Ping);
 				return;
 			}
 			return;
@@ -175,7 +181,7 @@ void AutoTele::OnLoop() {
 
 		if((GetTickCount() - _timer2) > 500) {
 			if(Try >= 5) {
-				PrintText(1, "�c4AutoTele:�c1 Failed to teleport after 5 tries");
+				PrintText(1, "\xFF" "c4AutoTele:" "\xFF" "c1 Failed to teleport after 5 tries");
 				TPath.RemoveAll();
 				Try = 0;
 				DoInteract = 0;
@@ -379,7 +385,7 @@ void AutoTele::ManageTele(Vector T) {
 	}
 
 	if(!T.Id) {
-		PrintText(1, "�c4AutoTele:�c1 Invalid destination");
+		PrintText(1, "\xFF" "c4AutoTele:" "\xFF" "c1 Invalid destination");
 		return;
 	}
 
@@ -415,7 +421,7 @@ void AutoTele::ManageTele(Vector T) {
 				} else DoInteract = 0;
 
 				int nodes = MakePath(ExitArray[i]->ptPos.x, ExitArray[i]->ptPos.y, Areas, AreaCount, ExitArray[i]->dwType == EXIT_LEVEL ? 1: 0);
-				PrintText(1, "�c4AutoTele:�c1 Going to %s, %d nodes.", lvltext->szName, nodes);
+				PrintText(1, "\xFF" "c4AutoTele:" "\xFF" "c1 Going to %s, %d nodes.", lvltext->szName, nodes);
 				break;
 			}
 		}
@@ -425,11 +431,11 @@ void AutoTele::ManageTele(Vector T) {
 	if(T.dwType == XY) {
 		DoInteract = 0;
 		if(!T.Id || !T.Id2) {
-			PrintText(1, "�c4AutoTele:�c1 No X/Y value found");
+			PrintText(1, "\xFF" "c4AutoTele:" "\xFF" "c1 No X/Y value found");
 			return;
 		}
 		int nodes = MakePath(T.Id, T.Id2, Areas, AreaCount, 0);
-		PrintText(1, "�c4AutoTele:�c1 Going to X: %d, Y: %d, %d nodes", T.Id, T.Id2, nodes);
+		PrintText(1, "\xFF" "c4AutoTele:" "\xFF" "c1 Going to X: %d, Y: %d, %d nodes", T.Id, T.Id2, nodes);
 		return;
 	}
 
@@ -451,13 +457,13 @@ void AutoTele::ManageTele(Vector T) {
 		if(nodes = MakePath(PresetUnit.x,PresetUnit.y, Areas, AreaCount, 0)) {
 			if(T.dwType == UNIT_OBJECT) {
 				ObjectTxt * ObjTxt = D2COMMON_GetObjectTxt(T.Id);
-				PrintText(1, "�c4AutoTele:�c1 Going to %s, %d nodes", ObjTxt->szName, nodes);
+				PrintText(1, "\xFF" "c4AutoTele:" "\xFF" "c1 Going to %s, %d nodes", ObjTxt->szName, nodes);
 			}
 			InteractType = T.dwType;
 		}
 		else return;
 	} else {
-		PrintText(1, "�c4AutoTele:�c1 Can't find object");
+		PrintText(1, "\xFF" "c4AutoTele:" "\xFF" "c1 Can't find object");
 		return;
 	}
 }

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -52,6 +52,16 @@
 #include "../../MPQInit.h"
 #include "lrucache.hpp"
 
+namespace {
+
+using ::Drawing::Checkhook;
+using ::Drawing::Combohook;
+using ::Drawing::Keyhook;
+using ::Drawing::Texthook;
+using ::Drawing::UITab;
+
+}  // namespace
+
 ItemsTxtStat* GetAllStatModifier(ItemsTxtStat* pStats, int nStats, int nStat, ItemsTxtStat* pOrigin);
 ItemsTxtStat* GetItemsTxtStatByMod(ItemsTxtStat* pStats, int nStats, int nStat, int nStatParam);
 RunesTxt* GetRunewordTxtById(int rwId);
@@ -78,8 +88,6 @@ Patch* permShowItems2 = new Patch(Call, D2CLIENT, { 0xC0E9A, 0x1A89A }, (int)Per
 Patch* permShowItems3 = new Patch(Call, D2CLIENT, { 0x59483, 0x4EA13 }, (int)PermShowItemsPatch2_ASM, 6);
 Patch* permShowItems4 = new Patch(Call, D2CLIENT, { 0x5908A, 0x4E61A }, (int)PermShowItemsPatch3_ASM, 6);
 Patch* permShowItems5 = new Patch(Call, D2CLIENT, { 0xA6BA3, 0x63443 }, (int)PermShowItemsPatch4_ASM, 6);
-
-using namespace Drawing;
 
 void Item::OnLoad() {
 	LoadConfig();

--- a/BH/Modules/Maphack/Maphack.cpp
+++ b/BH/Modules/Maphack/Maphack.cpp
@@ -15,7 +15,19 @@
 
 #pragma optimize( "", off)
 
-using namespace Drawing;
+namespace {
+
+using ::Drawing::Center;
+using ::Drawing::Checkhook;
+using ::Drawing::Colorhook;
+using ::Drawing::Combohook;
+using ::Drawing::Hook;
+using ::Drawing::Keyhook;
+using ::Drawing::Texthook;
+using ::Drawing::UITab;
+
+}  // namespace
+
 Patch* weatherPatch = new Patch(Jump, D2COMMON, { 0x6CC56, 0x30C36 }, (int)Weather_Interception, 5);
 Patch* lightingPatch = new Patch(Call, D2CLIENT, { 0xA9A37, 0x233A7 }, (int)Lighting_Interception, 6);
 Patch* infraPatch = new Patch(Call, D2CLIENT, { 0x66623, 0xB4A23 }, (int)Infravision_Interception, 7);

--- a/BH/Modules/Party/Party.cpp
+++ b/BH/Modules/Party/Party.cpp
@@ -7,9 +7,14 @@
 #include "../../D2Stubs.h"
 #include "../../D2Helpers.h"
 
-using namespace Drawing;
-Drawing::Hook* PartyHook;
-Drawing::Hook* LootHook;
+namespace {
+
+using ::Drawing::Hook;
+
+}  // namespace
+
+Hook* PartyHook;
+Hook* LootHook;
 
 void Party::OnLoad() {
 	BH::config->ReadToggle("Party Enabled", "None", true, Toggles["Enabled"]);

--- a/BH/Modules/ScreenInfo/ScreenInfo.cpp
+++ b/BH/Modules/ScreenInfo/ScreenInfo.cpp
@@ -11,7 +11,15 @@
 #include <numeric>
 #include <filesystem>
 
-using namespace Drawing;
+namespace {
+
+using ::Drawing::Center;
+using ::Drawing::OutOfGame;
+using ::Drawing::Perm;
+using ::Drawing::Right;
+using ::Drawing::Texthook;
+
+}  // namespace
 
 std::map<std::string, Toggle> ScreenInfo::Toggles;
 

--- a/BH/Modules/StashExport/StashExport.cpp
+++ b/BH/Modules/StashExport/StashExport.cpp
@@ -26,8 +26,8 @@ using ::Drawing::UITab;
 
 }  // namespace
 
-map<std::string, Toggle> StashExport::Toggles;
-map<std::string, std::unique_ptr<Mustache::AMustacheTemplate>> StashExport::MustacheTemplates;
+std::map<std::string, Toggle> StashExport::Toggles;
+std::map<std::string, std::unique_ptr<Mustache::AMustacheTemplate>> StashExport::MustacheTemplates;
 UnitAny* StashExport::viewingUnit;
 
 #define NAMEOF(statid) (AllStatList[statid]->name)

--- a/BH/Modules/StashExport/StashExport.cpp
+++ b/BH/Modules/StashExport/StashExport.cpp
@@ -18,13 +18,19 @@ using ::common::str_util::Trim;
 
 }  // namespace
 
-std::map<std::string, Toggle> StashExport::Toggles;
-std::map<std::string, std::unique_ptr<Mustache::AMustacheTemplate>> StashExport::MustacheTemplates;
+namespace {
+
+using ::Drawing::Checkhook;
+using ::Drawing::Combohook;
+using ::Drawing::UITab;
+
+}  // namespace
+
+map<std::string, Toggle> StashExport::Toggles;
+map<std::string, std::unique_ptr<Mustache::AMustacheTemplate>> StashExport::MustacheTemplates;
 UnitAny* StashExport::viewingUnit;
 
 #define NAMEOF(statid) (AllStatList[statid]->name)
-
-using namespace Drawing;
 
 void StashExport::OnLoad() {
 	LoadConfig();


### PR DESCRIPTION
These changes remove every single instance of `using namespace Drawing;` in the BH.dll codebase.

Various use cases are in implementation files (.cpp) that should have been scoped under the Drawing namespace. Other usages could be replaced with a using alias instead, which at least indicates which identifiers from Drawing are being used.

This should remove all remaining instance of `using namespace` in BH,.