### PR TITLE
Implement common::str_util::ToBool

### DIFF
--- a/BH/Common.cpp
+++ b/BH/Common.cpp
@@ -111,14 +111,6 @@ std::wstring GetColorCode(int ColNo)
 	return Result.str();
 }
 
-bool IsTrue(const char *str) {
-	return (_stricmp(str, "1") == 0 || _stricmp(str, "y") == 0 || _stricmp(str, "yes") == 0 || _stricmp(str, "true") == 0);
-}
-
-bool StringToBool(std::string str) {
-	return IsTrue(str.c_str());
-}
-
 int StringToNumber(std::string str) {
 	int ret;
 	if (!str.find("0x")) {

--- a/BH/Common.h
+++ b/BH/Common.h
@@ -69,8 +69,6 @@ bool from_string(T& t,
 template< class type> std::string to_string( const type & value)
 { std::stringstream ss; ss << value; return ss.str(); }
 
-bool IsTrue(const char *str);
-bool StringToBool(std::string str);
 int StringToNumber(std::string str);
 
 void PrintText(DWORD Color, char *szText, ...);

--- a/BH/Common/StringUtil.h
+++ b/BH/Common/StringUtil.h
@@ -25,10 +25,77 @@
 #ifndef BH_COMMON_STRING_UTIL_H_
 #define BH_COMMON_STRING_UTIL_H_
 
+#include <optional>
 #include <string>
 #include <string_view>
 
 namespace common::str_util {
+namespace ascii {
+
+// TODO (Mir Drualga): Make this constexpr in C++20.
+/**
+ * Returns a copy of the specified characters with all uppercase 7-bit
+ * ASCII characters converted to lowercase.
+ */
+template <typename CharT>
+std::basic_string<CharT> ToLower(const CharT* str);
+
+// TODO (Mir Drualga): Make this constexpr in C++20.
+/**
+ * Returns a copy of the specified characters with all uppercase 7-bit
+ * ASCII characters converted to lowercase.
+ */
+template <typename CharT>
+std::basic_string<CharT> ToLower(const std::basic_string<CharT>& str);
+
+// TODO (Mir Drualga): Make this constexpr in C++20.
+/**
+ * Returns a copy of the specified characters with all uppercase 7-bit
+ * ASCII characters converted to lowercase.
+ */
+template <typename CharT>
+std::basic_string<CharT> ToLower(std::basic_string_view<CharT> str);
+
+/**
+ * Returns the lowercase character for a specified character. If the
+ * character is not an uppercase character for 7-bit ASCII, then the
+ * function returns the unmodified character.
+ */
+template <typename CharT>
+constexpr CharT ToLowerChar(CharT ch);
+
+}  // namespace ascii
+
+/**
+ * String property functions
+ */
+
+// TODO (Mir Drualga): Make this constexpr in C++20.
+/**
+ * Returns true if the specified string is equal to "true" via
+ * case-insensitive comparison. Returns false if the same comparison
+ * applies to "false". Otherwise, returns nullopt.
+ */
+template <typename CharT>
+std::optional<bool> ToBool(const CharT* str);
+
+// TODO (Mir Drualga): Make this constexpr in C++20.
+/**
+ * Returns true if the specified string is equal to "true" via
+ * case-insensitive comparison. Returns false if the same comparison
+ * applies to "false". Otherwise, returns nullopt.
+ */
+template <typename CharT>
+std::optional<bool> ToBool(const std::basic_string<CharT>& str);
+
+// TODO (Mir Drualga): Make this constexpr in C++20.
+/**
+ * Returns true if the specified string is equal to "true" via
+ * case-insensitive comparison. Returns false if the same comparison
+ * applies to "false". Otherwise, returns nullopt.
+ */
+template <typename CharT>
+std::optional<bool> ToBool(std::basic_string_view<CharT> str);
 
 /**
  * String transformation functions

--- a/BH/Common/StringUtilTemplate.inc
+++ b/BH/Common/StringUtilTemplate.inc
@@ -29,10 +29,83 @@
 #ifndef BH_COMMON_STRING_UTIL_TEMPLATE_INC_
 #define BH_COMMON_STRING_UTIL_TEMPLATE_INC_
 
+#include <optional>
 #include <string>
 #include <string_view>
 
 namespace common::str_util {
+namespace ascii {
+
+template <typename CharT>
+std::basic_string<CharT> ToLower(const CharT* str) {
+  return ToLower(std::basic_string_view<CharT>(str));
+}
+
+template <typename CharT>
+std::basic_string<CharT> ToLower(const std::basic_string<CharT>& str) {
+  return ToLower(std::basic_string_view<CharT>(str));
+}
+
+template <typename CharT>
+std::basic_string<CharT> ToLower(std::basic_string_view<CharT> str) {
+  std::basic_string<CharT> lower_str(str.cbegin(), str.cend());
+  for (CharT& ch : lower_str) {
+    ch = ToLowerChar(ch);
+  }
+
+  return lower_str;
+}
+
+template <typename CharT>
+constexpr CharT ToLowerChar(CharT ch) {
+  if (ch < CharT('A') || ch > CharT('Z')) {
+    return ch;
+  }
+
+  constexpr auto kLowerToUpperDiff = CharT('a') - CharT('A');
+  return ch + kLowerToUpperDiff;
+}
+
+}  // namespace ascii
+
+/**
+ * String property functions
+ */
+
+template <typename CharT>
+std::optional<bool> ToBool(const CharT* str) {
+  return ToBool(std::basic_string_view<CharT>(str));
+}
+
+template <typename CharT>
+std::optional<bool> ToBool(const std::basic_string<CharT>& str) {
+  return ToBool(std::basic_string_view<CharT>(str.c_str(), str.length()));
+}
+
+template <typename CharT>
+std::optional<bool> ToBool(std::basic_string_view<CharT> str) {
+  constexpr CharT kTrueStr[] = {
+    CharT('t'), CharT('r'), CharT('u'), CharT('e'), CharT('\0')
+  };
+  constexpr std::basic_string_view<CharT> kTrueStrView = kTrueStr;
+  constexpr CharT kFalseStr[] = {
+    CharT('f'), CharT('a'), CharT('l'), CharT('s'), CharT('e'), CharT('\0')
+  };
+  constexpr std::basic_string_view<CharT> kFalseStrView = kFalseStr;
+
+  if (str.length() > kFalseStrView.length()) {
+    return std::nullopt;
+  }
+
+  std::basic_string<CharT> lower_str = ascii::ToLower(str);
+  if (lower_str == kTrueStrView) {
+    return std::make_optional(true);
+  } else if (lower_str == kFalseStrView) {
+    return std::make_optional(false);
+  }
+
+  return std::nullopt;
+}
 
 /**
  * String transformation functions

--- a/BH/Config.h
+++ b/BH/Config.h
@@ -51,7 +51,6 @@ private:
 	std::vector<std::pair<std::string, std::string>> orderedKeyVals;
 
 	static bool HasChanged(ConfigEntry entry, std::string& value);
-	static bool StringToBool(std::string input);
 public:
 	Config(std::string name) : configName(name) {};
 

--- a/BH/Drawing/UI/UI.cpp
+++ b/BH/Drawing/UI/UI.cpp
@@ -7,6 +7,7 @@
 
 #include "../../BH.h"
 #include "../../Common.h"
+#include "../../Common/StringUtil.h"
 #include "../../D2Ptrs.h"
 #include "../Basic/Texthook/Texthook.h"
 #include "../Basic/Framehook/Framehook.h"
@@ -14,6 +15,11 @@
 #include "UITab.h"
 
 namespace Drawing {
+namespace {
+
+using ::common::str_util::ToBool;
+
+}  // namespace
 
 std::list<UI*> UI::UIs;
 std::list<UI*> UI::Minimized;
@@ -34,7 +40,7 @@ UI::UI(std::string name, unsigned int xSize, unsigned int ySize) {
 	SetMinimizedY(minY);
 	char activeStr[20];
 	GetPrivateProfileString(name.c_str(), "Minimized", "true", activeStr, 20, path.c_str());
-	if (StringToBool(activeStr)) {
+	if (ToBool(activeStr).value_or(false) || strcmp(activeStr, "1") == 0) {
 		SetMinimized(true);
 		Minimized.push_back(this);
 	} else {
@@ -48,7 +54,7 @@ UI::~UI() {
 	Lock();
 	WritePrivateProfileString(name.c_str(), "X", to_string<unsigned int>(GetX()).c_str(), std::string(BH::path + "UI.ini").c_str());
 	WritePrivateProfileString(name.c_str(), "Y", to_string<unsigned int>(GetY()).c_str(), std::string(BH::path + "UI.ini").c_str());
-	WritePrivateProfileString(name.c_str(), "Minimized", to_string<bool>(IsMinimized()).c_str(), std::string(BH::path + "UI.ini").c_str());
+	WritePrivateProfileString(name.c_str(), "Minimized", IsMinimized() ? "true" : "false", std::string(BH::path + "UI.ini").c_str());
 	WritePrivateProfileString(name.c_str(), "minimizedX", to_string<unsigned int>(GetMinimizedX()).c_str(), std::string(BH::path + "UI.ini").c_str());
 	WritePrivateProfileString(name.c_str(), "minimizedY", to_string<unsigned int>(GetMinimizedY()).c_str(), std::string(BH::path + "UI.ini").c_str());
 
@@ -245,7 +251,7 @@ void UI::SetMinimized(bool newState) {
 	} else
 		Minimized.remove(this); 
 	minimized = newState; 
-	WritePrivateProfileString(name.c_str(), "Minimized", to_string<bool>(newState).c_str(), std::string(BH::path + "UI.ini").c_str());
+	WritePrivateProfileString(name.c_str(), "Minimized", newState ? "true" : "false", std::string(BH::path + "UI.ini").c_str());
 	Unlock(); 
 };
 

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -26,6 +26,7 @@
 
 namespace {
 
+using ::common::str_util::ToBool;
 using ::common::str_util::Trim;
 
 }  // namespace
@@ -1657,7 +1658,7 @@ void SkillListCondition::Init() {
 	// Build character skills list
 	BH::itemConfig->ReadAssoc("ClassSkillsList", skillList);
 	for (auto it = skillList.cbegin(); it != skillList.cend(); it++) {
-		if (StringToBool((*it).second)) {
+		if (ToBool((*it).second).value_or(false)) {
 			goodClassSkills.push_back(stoi((*it).first));
 		}
 	}
@@ -1665,7 +1666,7 @@ void SkillListCondition::Init() {
 	// Build tab skills list
 	BH::itemConfig->ReadAssoc("TabSkillsList", classSkillList);
 	for (auto it = classSkillList.cbegin(); it != classSkillList.cend(); it++) {
-		if (StringToBool((*it).second)) {
+		if (ToBool((*it).second).value_or(false)) {
 			goodTabSkills.push_back(stoi((*it).first));
 		}
 	}

--- a/BH/Modules/ScreenInfo/ScreenInfo.cpp
+++ b/BH/Modules/ScreenInfo/ScreenInfo.cpp
@@ -23,7 +23,7 @@
 #include <utility>
 
 #include "../../BH.h"
-#include "../../Common.h"
+#include "../../Common/StringUtil.h"
 #include "../../Config.h"
 #include "../../Constants.h"
 #include "../../D2Helpers.h"
@@ -41,6 +41,8 @@ using ::Drawing::OutOfGame;
 using ::Drawing::Perm;
 using ::Drawing::Right;
 using ::Drawing::Texthook;
+
+using ::common::str_util::ToBool;
 
 }  // namespace
 
@@ -110,7 +112,7 @@ void ScreenInfo::LoadConfig() {
 	BH::config->ReadAssoc("Skill Warning", SkillWarnings);
 	SkillWarningMap.clear();
 	for (auto it = SkillWarnings.cbegin(); it != SkillWarnings.cend(); it++) {
-		if (StringToBool((*it).second)) {
+		if (ToBool((*it).second).value_or(false)) {
 			// If the key is a number, it means warn when that state expires
 			DWORD stateId = 0;
 			std::stringstream ss((*it).first);


### PR DESCRIPTION
These changes add a function that does case-insensitive comparison for strings "true" and "false", and return nullopt if neither are found.

This can break compatibility with older configs that use "1", "yes", and "y" as alternatives to true, but the .cfg files tend to replace those entries with "True". UI.ini is the only case where a backwards compatibility option is added, because it writes "0" and "1" as values for "Minimized".