### PR TITLE
Implement common::str_util Integer check and Conversion functions

### DIFF
--- a/BH/Common.cpp
+++ b/BH/Common.cpp
@@ -119,16 +119,6 @@ bool StringToBool(std::string str) {
 	return IsTrue(str.c_str());
 }
 
-int StringToNumber(std::string str) {
-	int ret;
-	if (!str.find("0x")) {
-		from_string<int>(ret, str, std::hex);
-	} else {
-		from_string<int>(ret, str, std::dec);
-	}
-	return ret;
-}
-
 // This function prints at most 151 characters (152 including null)
 // TODO: Fix this so this limitation
 void PrintText(DWORD Color, char *szText, ...) {

--- a/BH/Common.h
+++ b/BH/Common.h
@@ -57,21 +57,12 @@ void Tokenize(const std::string& str, std::vector<std::string>& tokens, const st
 wchar_t* AnsiToUnicode(const char* str);
 char* UnicodeToAnsi(const wchar_t* str);
 std::wstring GetColorCode(int ColNo);
-template <class T>
-bool from_string(T& t, 
-                 const std::string& s, 
-                 std::ios_base& (*f)(std::ios_base&))
-{
-  std::istringstream iss(s);
-  return !(iss >> f >> t).fail();
-}
 
 template< class type> std::string to_string( const type & value)
 { std::stringstream ss; ss << value; return ss.str(); }
 
 bool IsTrue(const char *str);
 bool StringToBool(std::string str);
-int StringToNumber(std::string str);
 
 void PrintText(DWORD Color, char *szText, ...);
 

--- a/BH/Common/StringUtil.h
+++ b/BH/Common/StringUtil.h
@@ -65,6 +65,37 @@ constexpr std::optional<int> GetIntegerBaseFromPrefix(
     std::basic_string_view<CharT> str);
 
 /**
+ * Returns true if the specified character is representable as a
+ * decimal number.
+ */
+template <typename CharT>
+constexpr bool IsDecimalDigit(CharT ch);
+
+/**
+ * Returns true if the specified character is representable as a
+ * number with the specified integer-base encoding.
+ *
+ * Only the values in the interval [1, 36] are valid for base. The
+ * function will always return false if an invalid base is specified.
+ */
+template <typename CharT>
+constexpr bool IsDigitOfBase(CharT ch, int base);
+
+/**
+ * Returns true if the specified character is representable as a
+ * hexadecimal number.
+ */
+template <typename CharT>
+constexpr bool IsHexDigit(CharT ch);
+
+/**
+ * Returns true if the specified character is representable as an
+ * octal number.
+ */
+template <typename CharT>
+constexpr bool IsOctalDigit(CharT ch);
+
+/**
  * String transformation functions
  */
 

--- a/BH/Common/StringUtil.h
+++ b/BH/Common/StringUtil.h
@@ -261,5 +261,6 @@ constexpr std::optional<IntT> ToIntegerFromDigit(CharT ch, int base);
 }  // namespace common::str_util
 
 #include "StringUtilTemplate.inc"
+#include "StringUtilStaticTests.inc"
 
 #endif  // BH_COMMON_STRING_UTIL_H_

--- a/BH/Common/StringUtil.h
+++ b/BH/Common/StringUtil.h
@@ -25,6 +25,7 @@
 #ifndef BH_COMMON_STRING_UTIL_H_
 #define BH_COMMON_STRING_UTIL_H_
 
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -54,6 +55,14 @@ std::basic_string<CharT> Trim(const std::basic_string<CharT>& str);
  */
 template <typename CharT>
 std::basic_string<CharT> Trim(std::basic_string_view<CharT> str);
+
+/**
+ * Returns an integer value converted from a character. If the
+ * character is not a number, or cannot be represented with the
+ * integer type, then nullopt is returned instead.
+ */
+template <typename IntT, typename CharT>
+constexpr std::optional<IntT> ToIntegerFromDigit(CharT ch, int base);
 
 }  // namespace common::str_util
 

--- a/BH/Common/StringUtil.h
+++ b/BH/Common/StringUtil.h
@@ -32,6 +32,42 @@
 namespace common::str_util {
 
 /**
+ * String property functions
+ */
+
+/**
+ * Determines the integer-base encoding that matches the contents of
+ * the string. If the integer-base encoding could not be detected,
+ * then the function returns nullopt.
+ *
+ * Only supports detection of octal, decimal, and hexadecimal.
+ */
+template <typename CharT>
+constexpr std::optional<int> GetIntegerBase(const CharT* str);
+
+// TODO (Mir Drualga): Make this constexpr in C++20.
+/**
+ * Determines the integer-base encoding that matches the contents of
+ * the string. If the integer-base encoding could not be detected,
+ * then the function returns nullopt.
+ *
+ * Only supports detection of octal, decimal, and hexadecimal.
+ */
+template <typename CharT>
+std::optional<int> GetIntegerBase(const std::basic_string<CharT>& str);
+
+/**
+ * Determines the integer-base encoding that matches the contents of
+ * the string. If the integer-base encoding could not be detected,
+ * then the function returns nullopt.
+ *
+ * Only supports detection of octal, decimal, and hexadecimal.
+ */
+template <typename CharT>
+constexpr std::optional<int> GetIntegerBase(
+    std::basic_string_view<CharT> str);
+
+/**
  * Determines the integer-base encoding that matches the contents of
  * the string's prefix. If the integer-base encoding could not be
  * detected, then the function returns nullopt.

--- a/BH/Common/StringUtil.h
+++ b/BH/Common/StringUtil.h
@@ -32,6 +32,39 @@
 namespace common::str_util {
 
 /**
+ * Determines the integer-base encoding that matches the contents of
+ * the string's prefix. If the integer-base encoding could not be
+ * detected, then the function returns nullopt.
+ *
+ * Only supports detection of octal, decimal, and hexadecimal.
+ */
+template <typename CharT>
+constexpr std::optional<int> GetIntegerBaseFromPrefix(const CharT* str);
+
+// TODO (Mir Drualga): Make this constexpr in C++20.
+/**
+ * Determines the integer-base encoding that matches the contents of
+ * the string's prefix. If the integer-base encoding could not be
+ * detected, then the function returns nullopt.
+ *
+ * Only supports detection of octal, decimal, and hexadecimal.
+ */
+template <typename CharT>
+std::optional<int> GetIntegerBaseFromPrefix(
+    const std::basic_string<CharT>& str);
+
+/**
+ * Determines the integer-base encoding that matches the contents of
+ * the string's prefix. If the integer-base encoding could not be
+ * detected, then the function returns nullopt.
+ *
+ * Only supports detection of octal, decimal, and hexadecimal.
+ */
+template <typename CharT>
+constexpr std::optional<int> GetIntegerBaseFromPrefix(
+    std::basic_string_view<CharT> str);
+
+/**
  * String transformation functions
  */
 

--- a/BH/Common/StringUtil.h
+++ b/BH/Common/StringUtil.h
@@ -157,6 +157,34 @@ template <typename CharT>
 std::basic_string<CharT> Trim(std::basic_string_view<CharT> str);
 
 /**
+ * String-to-number functions
+ */
+
+/**
+ * Returns an integer value converted from a string. If the string is
+ * not a number, or cannot be represented with the interger type, then
+ * nullopt is returned instead.
+ */
+template <typename IntT, typename CharT>
+constexpr std::optional<IntT> ToInteger(const CharT* str);
+
+/**
+ * Returns an integer value converted from a string. If the string is
+ * not a number, or cannot be represented with the interger type, then
+ * nullopt is returned instead.
+ */
+template <typename IntT, typename CharT>
+constexpr std::optional<IntT> ToInteger(const std::basic_string<CharT>& str);
+
+/**
+ * Returns an integer value converted from a string. If the string is
+ * not a number, or cannot be represented with the interger type, then
+ * nullopt is returned instead.
+ */
+template <typename IntT, typename CharT>
+constexpr std::optional<IntT> ToInteger(std::basic_string_view<CharT> str);
+
+/**
  * Returns an integer value converted from a character. If the
  * character is not a number, or cannot be represented with the
  * integer type, then nullopt is returned instead.

--- a/BH/Common/StringUtil.h
+++ b/BH/Common/StringUtil.h
@@ -101,6 +101,28 @@ constexpr std::optional<int> GetIntegerBaseFromPrefix(
     std::basic_string_view<CharT> str);
 
 /**
+ * Returns true if the specified string is representable as a decimal
+ * number with the specified integer type.
+ */
+template <typename IntT, typename CharT>
+constexpr bool IsDecimal(const CharT* str);
+
+// TODO (Mir Drualga): Make this constexpr in C++20.
+/**
+ * Returns true if the specified string is representable as a decimal
+ * number with the specified integer type.
+ */
+template <typename IntT, typename CharT>
+bool IsDecimal(const std::basic_string<CharT>& str);
+
+/**
+ * Returns true if the specified string is representable as a decimal
+ * number with the specified integer type.
+ */
+template <typename IntT, typename CharT>
+constexpr bool IsDecimal(std::basic_string_view<CharT> str);
+
+/**
  * Returns true if the specified character is representable as a
  * decimal number.
  */
@@ -118,11 +140,55 @@ template <typename CharT>
 constexpr bool IsDigitOfBase(CharT ch, int base);
 
 /**
+ * Returns true if the specified string is representable as a
+ * hexadecimal number with the specified integer type.
+ */
+template <typename IntT, typename CharT>
+constexpr bool IsHex(const CharT* str);
+
+// TODO (Mir Drualga): Make this constexpr in C++20.
+/**
+ * Returns true if the specified string is representable as a
+ * hexadecimal number with the specified integer type.
+ */
+template <typename IntT, typename CharT>
+bool IsHex(const std::basic_string<CharT>& str);
+
+/**
+ * Returns true if the specified string is representable as a
+ * hexadecimal number with the specified integer type.
+ */
+template <typename IntT, typename CharT>
+constexpr bool IsHex(std::basic_string_view<CharT> str);
+
+/**
  * Returns true if the specified character is representable as a
  * hexadecimal number.
  */
 template <typename CharT>
 constexpr bool IsHexDigit(CharT ch);
+
+/**
+ * Returns true if the specified string is representable as an octal
+ * number with the specified integer type.
+ */
+template <typename IntT, typename CharT>
+constexpr bool IsOctal(const CharT* str);
+
+// TODO (Mir Drualga): Make this constexpr in C++20.
+/**
+ * Returns true if the specified string is representable as an octal
+ * number.
+ */
+template <typename CharT>
+bool IsOctal(const std::basic_string<CharT>& str);
+
+/**
+ * Returns true if the specified string is representable as an octal
+ * number.
+ */
+template <typename CharT>
+constexpr bool IsOctal(std::basic_string_view<CharT> str);
 
 /**
  * Returns true if the specified character is representable as an

--- a/BH/Common/StringUtilStaticTests.inc
+++ b/BH/Common/StringUtilStaticTests.inc
@@ -1,0 +1,166 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) SlashDiablo Community
+ *
+ * BH
+ * Copyright 2011 (C) McGod
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#if !defined(BH_COMMON_STRING_UTIL_H_)
+#error This file is not to be directly included by external users.
+#endif  // !defined(BH_COMMON_STRING_UTIL_H_)
+
+#if !defined(BH_COMMON_STRING_UTIL_TEMPLATE_INC_)
+#error Constexpr functions must be defined before including the static tests.
+#endif  // !defined(BH_COMMON_STRING_UTIL_TEMPLATE_INC_)
+
+#ifndef BH_COMMON_STRING_UTIL_STATIC_TEST_INC_
+#define BH_COMMON_STRING_UTIL_STATIC_TEST_INC_
+
+#include <limits>
+
+namespace common::str_util {
+
+static_assert(!ToIntegerFromDigit<int>('0', 0));
+static_assert(!ToIntegerFromDigit<int>(L'0', 0));
+static_assert(!ToIntegerFromDigit<int>('0', 37));
+static_assert(!ToIntegerFromDigit<int>('.', 36));
+static_assert(!ToIntegerFromDigit<int>('/', 36));
+static_assert(!ToIntegerFromDigit<int>('\xFF', 36));
+static_assert(ToIntegerFromDigit<int>('z', 36) == 35);
+static_assert(ToIntegerFromDigit<int>('G', 36) == 16);
+static_assert(!ToIntegerFromDigit<int>('.', 36));
+static_assert(ToIntegerFromDigit<int>('Y', 35) == 34);
+static_assert(ToIntegerFromDigit<int>('g', 35) == 16);
+static_assert(!ToIntegerFromDigit<int>('Z', 35));
+static_assert(ToIntegerFromDigit<int>('f', 16) == 15);
+static_assert(ToIntegerFromDigit<int>('A', 16) == 10);
+static_assert(!ToIntegerFromDigit<int>('i', 16));
+static_assert(ToIntegerFromDigit<int>('9', 10) == 9);
+static_assert(ToIntegerFromDigit<int>('8', 10) == 8);
+static_assert(!ToIntegerFromDigit<int>('A', 10));
+static_assert(ToIntegerFromDigit<int>('7', 8) == 7);
+static_assert(ToIntegerFromDigit<int>('1', 8) == 1);
+static_assert(!ToIntegerFromDigit<int>('8', 8));
+
+static_assert(GetIntegerBaseFromPrefix("0xa") == 16);
+static_assert(GetIntegerBaseFromPrefix(L"0xa") == 16);
+static_assert(GetIntegerBaseFromPrefix("-0xa") == 16);
+static_assert(GetIntegerBaseFromPrefix("0xF") == 16);
+static_assert(GetIntegerBaseFromPrefix("-0xF") == 16);
+static_assert(GetIntegerBaseFromPrefix("18") == 10);
+static_assert(GetIntegerBaseFromPrefix("07") == 8);
+static_assert(GetIntegerBaseFromPrefix("0x7F") == 16);
+static_assert(GetIntegerBaseFromPrefix("-0x7F") == 16);
+
+static_assert(GetIntegerBaseFromPrefix("0xz") == 16);
+static_assert(!GetIntegerBaseFromPrefix("f"));
+static_assert(!GetIntegerBaseFromPrefix("X"));
+static_assert(!GetIntegerBaseFromPrefix("a"));
+static_assert(GetIntegerBaseFromPrefix("08") == 8);
+static_assert(GetIntegerBaseFromPrefix("99999999999999999999") == 10);
+static_assert(GetIntegerBaseFromPrefix("257") == 10);
+static_assert(GetIntegerBaseFromPrefix("0x100") == 16);
+static_assert(GetIntegerBaseFromPrefix("0x") == 16);
+static_assert(!GetIntegerBaseFromPrefix(""));
+static_assert(GetIntegerBaseFromPrefix("0X") == 16);
+static_assert(GetIntegerBaseFromPrefix("0x80") == 16);
+
+static_assert(ToInteger<int>("0xa") == 10);
+static_assert(ToInteger<int>(L"0xa") == 10);
+static_assert(ToInteger<int>("-0xa") == -10);
+static_assert(ToInteger<int>("0xF") == 15);
+static_assert(ToInteger<int>("-0xF") == -15);
+static_assert(ToInteger<int>("18") == 18);
+static_assert(ToInteger<int>("07") == 7);
+static_assert(
+    ToInteger<unsigned int>("0xFFffFFff")
+        == std::numeric_limits<unsigned int>::max());
+static_assert(ToInteger<signed char>("0x7F") == 127);
+static_assert(ToInteger<signed char>("-0x7F") == -127);
+static_assert(ToInteger<signed char>("-0x80") == -128);
+static_assert(
+    ToInteger<unsigned char>("0xfF")
+        == std::numeric_limits<unsigned char>::max());
+
+static_assert(!ToInteger<int>("0xz"));
+static_assert(!ToInteger<int>("f"));
+static_assert(!ToInteger<int>("X"));
+static_assert(!ToInteger<int>("a"));
+static_assert(!ToInteger<int>("08"));
+static_assert(!ToInteger<signed char>("0x80"));
+static_assert(!ToInteger<int>("0xfffffffF"));
+static_assert(!ToInteger<int>("99999999999999999999999999"));
+static_assert(!ToInteger<unsigned char>("257"));
+static_assert(!ToInteger<unsigned char>("0x100"));
+static_assert(!ToInteger<int>("0x"));
+static_assert(!ToInteger<int>(""));
+static_assert(!ToInteger<int>("0X"));
+static_assert(!ToInteger<signed char>("0x80"));
+
+static_assert(IsDecimal<unsigned char>("0"));
+static_assert(IsDecimal<unsigned char>(L"0"));
+static_assert(IsDecimal<unsigned char>("255"));
+static_assert(!IsDecimal<unsigned char>("256"));
+static_assert(!IsDecimal<unsigned char>(""));
+static_assert(!IsDecimal<unsigned char>("\t"));
+static_assert(!IsDecimal<unsigned char>("Hello world!"));
+static_assert(!IsDecimal<unsigned char>("0x0"));
+static_assert(!IsDecimal<unsigned char>("0xFF"));
+static_assert(!IsDecimal<unsigned char>("010"));
+static_assert(!IsDecimal<unsigned char>("00"));
+static_assert(!IsDecimal<unsigned char>("07"));
+
+static_assert(IsHex<unsigned char>("0x0"));
+static_assert(IsHex<unsigned char>(L"0x0"));
+static_assert(IsHex<unsigned char>("0x00"));
+static_assert(IsHex<unsigned char>("0xFF"));
+static_assert(!IsHex<unsigned char>("0x100"));
+static_assert(IsHex<unsigned int>("0x100"));
+static_assert(IsHex<unsigned char>("0x00000000FF"));
+static_assert(!IsHex<unsigned char>("0xG"));
+static_assert(!IsHex<unsigned char>(""));
+static_assert(!IsHex<unsigned char>("\t"));
+static_assert(!IsHex<unsigned char>("Hello world!"));
+static_assert(!IsHex<unsigned char>("0"));
+static_assert(!IsHex<unsigned char>("10"));
+static_assert(!IsHex<unsigned char>("01"));
+static_assert(!IsHex<unsigned char>("07"));
+
+static_assert(IsOctal<unsigned char>("00"));
+static_assert(IsOctal<unsigned char>(L"00"));
+static_assert(IsOctal<unsigned char>("01"));
+static_assert(IsOctal<unsigned char>("0377"));
+static_assert(IsOctal<unsigned char>("000000000377"));
+static_assert(!IsOctal<unsigned char>("0400"));
+static_assert(IsOctal<unsigned int>("0400"));
+static_assert(!IsOctal<unsigned char>("08"));
+static_assert(!IsOctal<unsigned char>(""));
+static_assert(!IsOctal<unsigned char>("\t"));
+static_assert(!IsOctal<unsigned char>("Hello world!"));
+static_assert(!IsOctal<unsigned char>("0"));
+static_assert(!IsOctal<unsigned char>("0x10"));
+static_assert(!IsOctal<unsigned char>("0x01"));
+static_assert(!IsOctal<unsigned char>("0x07"));
+static_assert(!IsOctal<unsigned char>("1"));
+static_assert(!IsOctal<unsigned char>("7"));
+
+}  // namespace common::str_util
+
+#endif  // BH_COMMON_STRING_UTIL_STATIC_TEST_INC_

--- a/BH/Common/StringUtilTemplate.inc
+++ b/BH/Common/StringUtilTemplate.inc
@@ -31,6 +31,7 @@
 
 #include <assert.h>
 
+#include <limits>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -207,6 +208,107 @@ template <typename CharT>
 std::optional<int> GetIntegerBase(
     const std::basic_string<CharT>& str) {
   return GetIntegerBase<CharT>(std::basic_string_view<CharT>(str));
+}
+
+template <typename IntT, typename CharT>
+constexpr std::optional<IntT> ToInteger(std::basic_string_view<CharT> str) {
+  using size_type = std::basic_string_view<CharT>::size_type;
+  using numeric_limits = std::numeric_limits<IntT>;
+
+  if (str.empty()) {
+    return std::nullopt;
+  }
+
+  // Check if the digit is valid for the detected prefix's base. If
+  // it is valid, get the value.
+  std::optional<int> prefix_base_optional =
+      GetIntegerBaseFromPrefix<CharT>(str);
+  if (!prefix_base_optional.has_value()) {
+    return std::nullopt;
+  }
+  int prefix_base = *prefix_base_optional;
+
+  // Do not allow unsigned numbers to have negative numbers.
+  bool is_negative = (str[0] == '-');
+  if constexpr (!numeric_limits::is_signed) {
+    // We use std::numeric_limits::is_signed instead of <type_traits>
+    // std::is_signed so that custom integer-like types can be used
+    // in this function.
+    if (is_negative) {
+      return std::nullopt;
+    }
+  }
+
+  size_type start_index = (is_negative) ? 1 : 0;
+  switch (prefix_base) {
+    case 8: {
+      start_index += 1;
+      break;
+    }
+
+    case 10: {
+      break;
+    }
+
+    case 16: {
+      start_index += 2;
+      break;
+    }
+
+    default: {
+      // This should never happen.
+      assert(false);
+      return std::nullopt;
+    }
+  }
+
+  if (str.length() <= start_index) {
+    return std::nullopt;
+  }
+
+  // Convert the string to the integer type.
+  IntT limit =
+      is_negative ? numeric_limits::lowest() : numeric_limits::max();
+  IntT value = 0;
+  for (CharT ch : str.substr(start_index)) {
+    // Check if the string has too many digits.
+    if ((is_negative && value < (limit / prefix_base))
+        || (!is_negative && value > (limit / prefix_base))) {
+      return std::nullopt;
+    }
+    value *= prefix_base;
+
+    // Check if the digit is valid for the detected prefix's base.
+    // If it is valid, get the value.
+    std::optional<IntT> digit_optional =
+        ToIntegerFromDigit<IntT>(ch, prefix_base);
+    if (!digit_optional.has_value()) {
+      return std::nullopt;
+    }
+    IntT digit = *digit_optional;
+
+    // Check if add/sub of this digit to the value would go
+    // over/under the limit.
+    if ((is_negative && value < (limit + digit))
+      || (!is_negative && value > (limit - digit))) {
+      return std::nullopt;
+    }
+
+    value += (is_negative ? -1 : 1) * digit;
+  }
+
+  return value;
+}
+
+template <typename IntT, typename CharT>
+constexpr std::optional<IntT> ToInteger(const CharT* str) {
+  return ToInteger<IntT, CharT>(std::basic_string_view<CharT>(str));
+}
+
+template <typename IntT, typename CharT>
+constexpr std::optional<IntT> ToInteger(
+    const std::basic_string<CharT>& str) {
+  return ToInteger<IntT, CharT>(std::basic_string_view<CharT>(str));
 }
 
 /**

--- a/BH/Common/StringUtilTemplate.inc
+++ b/BH/Common/StringUtilTemplate.inc
@@ -311,6 +311,66 @@ constexpr std::optional<IntT> ToInteger(
   return ToInteger<IntT, CharT>(std::basic_string_view<CharT>(str));
 }
 
+template <typename IntT, typename CharT>
+constexpr bool IsDecimal(std::basic_string_view<CharT> str) {
+  std::optional<int> base_optional = GetIntegerBase<CharT>(str);
+  if (base_optional != 10) {
+    return false;
+  }
+
+  return ToInteger<IntT, CharT>(str).has_value();
+}
+
+template <typename IntT, typename CharT>
+constexpr bool IsDecimal(const CharT* str) {
+  return IsDecimal<IntT, CharT>(std::basic_string_view<CharT>(str));
+}
+
+template <typename IntT, typename CharT>
+bool IsDecimal(const std::basic_string<CharT>& str) {
+  return IsDecimal<IntT, CharT>(std::basic_string_view<CharT>(str));
+}
+
+template <typename IntT, typename CharT>
+constexpr bool IsHex(std::basic_string_view<CharT> str) {
+  std::optional<int> base_optional = GetIntegerBase<CharT>(str);
+  if (base_optional != 16) {
+    return false;
+  }
+
+  return ToInteger<IntT, CharT>(str).has_value();
+}
+
+template <typename IntT, typename CharT>
+constexpr bool IsHex(const CharT* str) {
+  return IsHex<IntT, CharT>(std::basic_string_view<CharT>(str));
+}
+
+template <typename IntT, typename CharT>
+bool IsHex(const std::basic_string<CharT>& str) {
+  return IsHex<IntT, CharT>(std::basic_string_view<CharT>(str));
+}
+
+template <typename IntT, typename CharT>
+constexpr bool IsOctal(std::basic_string_view<CharT> str) {
+  std::optional<int> base_optional = GetIntegerBase<CharT>(str);
+  if (base_optional != 8) {
+    return false;
+  }
+
+  return ToInteger<IntT, CharT>(str).has_value();
+}
+
+template <typename IntT, typename CharT>
+constexpr bool IsOctal(const CharT* str) {
+  return IsOctal<IntT, CharT>(std::basic_string_view<CharT>(str));
+}
+
+template <typename IntT, typename CharT>
+bool IsOctal(const std::basic_string<CharT>& str) {
+  return IsOctal<IntT, CharT>(std::basic_string_view<CharT>(str));
+}
+
 /**
  * Non-constexpr functions
  */

--- a/BH/Common/StringUtilTemplate.inc
+++ b/BH/Common/StringUtilTemplate.inc
@@ -121,6 +121,26 @@ std::optional<int> GetIntegerBaseFromPrefix(
   return GetIntegerBaseFromPrefix<CharT>(std::basic_string_view<CharT>(str));
 }
 
+template <typename CharT>
+constexpr bool IsDigitOfBase(CharT ch, int base) {
+  return ToIntegerFromDigit<unsigned char>(ch, base).has_value();
+}
+
+template <typename CharT>
+constexpr bool IsDecimalDigit(CharT ch) {
+  return IsDigitOfBase<CharT>(ch, 10);
+}
+
+template <typename CharT>
+constexpr bool IsHexDigit(CharT ch) {
+  return IsDigitOfBase<CharT>(ch, 16);
+}
+
+template <typename CharT>
+constexpr bool IsOctalDigit(CharT ch) {
+  return IsDigitOfBase<CharT>(ch, 8);
+}
+
 /**
  * Non-constexpr functions
  */

--- a/BH/Common/StringUtilTemplate.inc
+++ b/BH/Common/StringUtilTemplate.inc
@@ -72,6 +72,55 @@ constexpr std::optional<IntT> ToIntegerFromDigit(CharT ch, int base) {
   return value;
 }
 
+template <typename CharT>
+constexpr std::optional<int> GetIntegerBaseFromPrefix(
+    std::basic_string_view<CharT> str) {
+  using size_type = std::basic_string_view<CharT>::size_type;
+
+  if (str.empty()) {
+    return std::nullopt;
+  }
+
+  // Track the negative sign.
+  bool is_negative = (str[0] == CharT('-'));
+
+  size_type start_index = is_negative ? 1 : 0;
+  if (str[start_index] == CharT('0')) {
+    if (str.length() == start_index + 1) {
+      // The string is "0" or "-0", so the prefix is decimal.
+      return 10;
+    }
+    assert(str.length() > start_index + 1);
+
+    if (str[start_index + 1] == CharT('x')
+        || str[start_index + 1] == CharT('X')) {
+      // The string starts with "0x" or "0X", so the prefix is hexadecimal.
+      return 16;
+    }
+
+    // The string starts with "0", so the prefix is octal.
+    return 8;
+  }
+
+  if (str[start_index] >= CharT('1') && str[start_index] <= CharT('9')) {
+    // The prefix is decimal.
+    return 10;
+  }
+
+  return std::nullopt;
+}
+
+template <typename CharT>
+constexpr std::optional<int> GetIntegerBaseFromPrefix(const CharT* str) {
+  return GetIntegerBaseFromPrefix<CharT>(std::basic_string_view<CharT>(str));
+}
+
+template <typename CharT>
+std::optional<int> GetIntegerBaseFromPrefix(
+    const std::basic_string<CharT>& str) {
+  return GetIntegerBaseFromPrefix<CharT>(std::basic_string_view<CharT>(str));
+}
+
 /**
  * Non-constexpr functions
  */

--- a/BH/Common/StringUtilTemplate.inc
+++ b/BH/Common/StringUtilTemplate.inc
@@ -29,13 +29,51 @@
 #ifndef BH_COMMON_STRING_UTIL_TEMPLATE_INC_
 #define BH_COMMON_STRING_UTIL_TEMPLATE_INC_
 
+#include <optional>
 #include <string>
 #include <string_view>
 
+/*
+ * Unlike the forward declarations, everything constexpr needs to be
+ * declared in an upstream to downstream dependency order, otherwise
+ * the function will not be recognized as constexpr (due to inline
+ * rules).
+ *
+ * This means that anything with zero dependencies should sit near the
+ * top of this file.
+ */
+
 namespace common::str_util {
 
+template <typename IntT, typename CharT>
+constexpr std::optional<IntT> ToIntegerFromDigit(CharT ch, int base) {
+  // Only the values in interval [1, 36] are valid for base.
+  if (base < 1 || base > 36) {
+    return std::nullopt;
+  }
+
+  // This compare of CharT against char is safe, because 7-bit ASCII
+  // characters use the same value to represent characters in the
+  // 0-128 range. CharT being signed or unsigned does not matter.
+
+  std::optional<IntT> value = std::nullopt;
+  if (ch >= CharT('0') && ch <= CharT('9')) {
+    value = std::make_optional<IntT>(ch - CharT('0'));
+  } else if (ch >= CharT('a') && ch <= CharT('z')) {
+    value = std::make_optional<IntT>(ch - CharT('a') + 10);
+  } else if (ch >= CharT('A') && ch <= CharT('Z')) {
+    value = std::make_optional<IntT>(ch - CharT('A') + 10);
+  }
+
+  if (value >= IntT(base)) {
+    return std::nullopt;
+  }
+
+  return value;
+}
+
 /**
- * String transformation functions
+ * Non-constexpr functions
  */
 
 template <typename CharT>

--- a/BH/Common/StringUtilTemplate.inc
+++ b/BH/Common/StringUtilTemplate.inc
@@ -29,6 +29,8 @@
 #ifndef BH_COMMON_STRING_UTIL_TEMPLATE_INC_
 #define BH_COMMON_STRING_UTIL_TEMPLATE_INC_
 
+#include <assert.h>
+
 #include <optional>
 #include <string>
 #include <string_view>
@@ -139,6 +141,72 @@ constexpr bool IsHexDigit(CharT ch) {
 template <typename CharT>
 constexpr bool IsOctalDigit(CharT ch) {
   return IsDigitOfBase<CharT>(ch, 8);
+}
+
+template <typename CharT>
+constexpr std::optional<int> GetIntegerBase(
+    std::basic_string_view<CharT> str) {
+  using size_type = std::basic_string_view<CharT>::size_type;
+
+  if (str.empty()) {
+    return std::nullopt;
+  }
+
+  std::optional<int> prefix_base_optional =
+      GetIntegerBaseFromPrefix<CharT>(str);
+  if (!prefix_base_optional.has_value()) {
+    return std::nullopt;
+  }
+  int prefix_base = *prefix_base_optional;
+
+  // Make sure our string meets minimum length requirement for the
+  // prefix's base.
+  size_type start_index = (str[0] == '-') ? 1 : 0;
+  switch (prefix_base) {
+    case 8: {
+      start_index += 1;
+      break;
+    }
+
+    case 10: {
+      break;
+    }
+
+    case 16: {
+      start_index += 2;
+      break;
+    }
+
+    default: {
+      // This should never happen.
+      assert(false);
+      return std::nullopt;
+    }
+  }
+
+  if (str.length() <= start_index) {
+    return std::nullopt;
+  }
+
+  // Check that all characters match with the prefix's base.
+  for (CharT ch : str.substr(start_index)) {
+    if (!IsDigitOfBase(ch, prefix_base)) {
+      return std::nullopt;
+    }
+  }
+
+  return prefix_base_optional;
+}
+
+template <typename CharT>
+constexpr std::optional<int> GetIntegerBase(const CharT* str) {
+  return GetIntegerBase<CharT>(std::basic_string_view<CharT>(str));
+}
+
+template <typename CharT>
+std::optional<int> GetIntegerBase(
+    const std::basic_string<CharT>& str) {
+  return GetIntegerBase<CharT>(std::basic_string_view<CharT>(str));
 }
 
 /**

--- a/BH/Modules/Maphack/Maphack.cpp
+++ b/BH/Modules/Maphack/Maphack.cpp
@@ -15,6 +15,7 @@
 
 #include "../../AsyncDrawBuffer.h"
 #include "../../BH.h"
+#include "../../Common/StringUtil.h"
 #include "../../Config.h"
 #include "../../Constants.h"
 #include "../../D2DataTables.h"
@@ -47,6 +48,8 @@ using ::Drawing::Hook;
 using ::Drawing::Keyhook;
 using ::Drawing::Texthook;
 using ::Drawing::UITab;
+
+using ::common::str_util::ToInteger;
 
 }  // namespace
 
@@ -131,12 +134,34 @@ void Maphack::ReadConfig() {
 	std::vector<std::pair<std::string, std::string>> enhancementColorsString;
 	BH::config->ReadMapList("Enhancement Color", enhancementColorsString);
 	for (auto& entry : enhancementColorsString) {
-		enhancementColors.push_back(std::pair(StringToNumber(entry.first), StringToNumber(entry.second)));
+		std::optional enhancementOptional =
+				ToInteger<unsigned int>(entry.first);
+		if (!enhancementOptional.has_value()) {
+			continue;
+		}
+
+		std::optional colorOptional = ToInteger<unsigned int>(entry.second);
+		if (!colorOptional.has_value()) {
+			continue;
+		}
+
+		enhancementColors.push_back(
+				std::make_pair(*enhancementOptional, *colorOptional));
 	}
 	std::vector<std::pair<std::string, std::string>> auraColorsString;
 	BH::config->ReadMapList("Aura Color", auraColorsString);
 	for (auto& entry : auraColorsString) {
-		auraColors.push_back(std::pair(StringToNumber(entry.first), StringToNumber(entry.second)));
+		std::optional auraOptional = ToInteger<unsigned int>(entry.first);
+		if (!auraOptional.has_value()) {
+			continue;
+		}
+
+		std::optional colorOptional = ToInteger<unsigned int>(entry.second);
+		if (!colorOptional.has_value()) {
+			continue;
+		}
+
+		auraColors.push_back(std::make_pair(*auraOptional, *colorOptional));
 	}
 
 
@@ -148,8 +173,11 @@ void Maphack::ReadConfig() {
 		if ((ss >> monsterId).fail()) {
 			continue;
 		} else {
-			int monsterColor = StringToNumber((*it).second);
-			automapMonsterColors[monsterId] = monsterColor;
+			std::optional colorOptional = ToInteger<unsigned int>(it->second);
+			if (!colorOptional.has_value()) {
+				continue;
+			}
+			automapMonsterColors[monsterId] = *colorOptional;
 		}
 	}
 
@@ -162,8 +190,11 @@ void Maphack::ReadConfig() {
 			continue;
 		}
 		else {
-			int monsterColor = StringToNumber((*it).second);
-			automapSuperUniqueColors[monsterId] = monsterColor;
+			std::optional colorOptional = ToInteger<unsigned int>(it->second);
+			if (!colorOptional.has_value()) {
+				continue;
+			}
+			automapSuperUniqueColors[monsterId] = *colorOptional;
 		}
 	}
 
@@ -176,8 +207,11 @@ void Maphack::ReadConfig() {
 		if ((ss >> monsterId).fail()) {
 			continue;
 		} else {
-			int lineColor = StringToNumber((*it).second);
-			automapMonsterLines[monsterId] = lineColor;
+			std::optional colorOptional = ToInteger<unsigned int>(it->second);
+			if (!colorOptional.has_value()) {
+				continue;
+			}
+			automapMonsterLines[monsterId] = *colorOptional;
 		}
 	}
 


### PR DESCRIPTION
These changes add a set of functions that are useful for string-to-integer conversions, and replaces instances of the old Common.h code with these functions.