### PR TITLE
Add precompile headers

### DIFF
--- a/BH/BH.vcxproj
+++ b/BH/BH.vcxproj
@@ -55,7 +55,7 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <TargetExt>.dll</TargetExt>
-    <IncludePath>$(INCLUDE);$(IncludePath);..\ThirdParty\cpp-lru-cache\include</IncludePath>
+    <IncludePath>$(INCLUDE);$(IncludePath);..\ThirdParty\cpp-lru-cache\include;.</IncludePath>
     <LibraryPath>..\ThirdParty\;$(LIBPATH);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Packaging|Win32'">
@@ -64,7 +64,7 @@
     <LibraryPath>..\ThirdParty\;$(LIBPATH);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <IncludePath>$(INCLUDE);$(IncludePath);..\ThirdParty\cpp-lru-cache\include</IncludePath>
+    <IncludePath>$(INCLUDE);$(IncludePath);..\ThirdParty\cpp-lru-cache\include;.</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LibraryPath>..\ThirdParty\;$(LIBPATH);$(LibraryPath)</LibraryPath>
@@ -75,6 +75,9 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>internal/pch.hpp</PrecompiledHeaderFile>
+      <ForcedIncludeFiles>internal/pch.hpp</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -100,6 +103,9 @@ if defined D2Path (
       <LanguageStandard>stdcpp17</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
       <PreprocessorDefinitions>_WINDLL;NOMINMAX;$(CustomDefinitions);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>internal/pch.hpp</PrecompiledHeaderFile>
+      <ForcedIncludeFiles>internal/pch.hpp;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -167,6 +173,10 @@ if defined D2Path (
     <ClCompile Include="Drawing\Stats\StatsDisplay.cpp" />
     <ClCompile Include="Drawing\UI\UI.cpp" />
     <ClCompile Include="Drawing\UI\UITab.cpp" />
+    <ClCompile Include="internal\pch.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="JSONObject.cpp" />
     <ClCompile Include="Modules\AutoTele\AutoTele.cpp" />
     <ClCompile Include="Modules\Bnet\Bnet.cpp" />
@@ -227,6 +237,8 @@ if defined D2Path (
     <ClInclude Include="Drawing\Stats\StatsDisplay.h" />
     <ClInclude Include="Drawing\UI\UI.h" />
     <ClInclude Include="Drawing\UI\UITab.h" />
+    <ClInclude Include="internal\pch.h" />
+    <ClInclude Include="internal\pch.hpp" />
     <ClInclude Include="JSONObject.h" />
     <ClInclude Include="Modules\AutoTele\ATIncludes\ArrayEx.h" />
     <ClInclude Include="Modules\AutoTele\ATIncludes\CMapIncludes.h" />

--- a/BH/BH.vcxproj.filters
+++ b/BH/BH.vcxproj.filters
@@ -54,6 +54,7 @@
     <ClCompile Include="TableReader.cpp" />
     <ClCompile Include="Task.cpp" />
     <ClCompile Include="Common\Input.cpp" />
+    <ClCompile Include="internal\pch.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AsyncDrawBuffer.h" />
@@ -127,5 +128,7 @@
     <ClInclude Include="Common\Input.h" />
     <ClInclude Include="Common\StringUtil.h" />
     <ClInclude Include="Common\StringUtilTemplate.inc" />
+    <ClInclude Include="internal\pch.h" />
+    <ClInclude Include="internal\pch.hpp" />
   </ItemGroup>
 </Project>

--- a/BH/CMakeLists.txt
+++ b/BH/CMakeLists.txt
@@ -64,8 +64,20 @@ set(DRAWING_SOURCES "Drawing/Hook.cpp"
                     "Drawing/UI/UI.cpp"
                     "Drawing/UI/UITab.cpp")
 
+set(PCH_C_FILES
+    "${CMAKE_CURRENT_SOURCE_DIR}/internal/pch.h"]]
+)
+
+set(PCH_CPP_FILES
+    "${CMAKE_CURRENT_SOURCE_DIR}/internal/pch.hpp"
+)
+
 set(SOURCE_FILES ${SOURCE_FILES} ${COMMON_SOURCES} ${ITEM_DISPLAY_SOURCES} ${MODULE_SOURCES} ${DRAWING_SOURCES})
 add_library(BH SHARED ${SOURCE_FILES})
+target_precompile_headers(BH PRIVATE
+    "$<$<COMPILE_LANGUAGE:C>:${PCH_C_FILES}>"
+    "$<$<COMPILE_LANGUAGE:CXX>:${PCH_CPP_FILES}>"
+)
 target_compile_definitions(BH PRIVATE NOMINMAX)
 target_compile_options(BH PRIVATE /permissive)
 target_include_directories(BH PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../ThirdParty/cpp-lru-cache/include)

--- a/BH/internal/pch.cpp
+++ b/BH/internal/pch.cpp
@@ -1,0 +1,20 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */

--- a/BH/internal/pch.h
+++ b/BH/internal/pch.h
@@ -1,0 +1,28 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef BH_INTERNAL_PCH_H_
+#define BH_INTERNAL_PCH_H_
+
+#include <windows.h>
+#include <shlwapi.h>
+
+#endif  /* BH_INTERNAL_PCH_H_ */

--- a/BH/internal/pch.hpp
+++ b/BH/internal/pch.hpp
@@ -1,0 +1,59 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef BH_INTERNAL_PCH_HPP_
+#define BH_INTERNAL_PCH_HPP_
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <deque>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iomanip>
+#include <ios>
+#include <iostream>
+#include <limits>
+#include <list>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <ostream>
+#include <regex>
+#include <set>
+#include <sstream>
+#include <stack>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "pch.h"
+
+#endif  // BH_INTERNAL_PCH_HPP_


### PR DESCRIPTION
These changes add precompile headers, which significantly reduces compile times. Previously, compiles could take at least 2 minutes, but precompile headers reduces this to at most 1 minute on my machine.

These changes come with the side effect of force including the precompile header everywhere, which can lead to includes not being added in when they should. From now on, all files should be written under the assumption that the precompile headers are not included.

These changes do not affect behavior of the program.