### PR TITLE
Remove event/raise and hook/unhook from modules

### DIFF
--- a/BH/D2Handlers.cpp
+++ b/BH/D2Handlers.cpp
@@ -11,23 +11,23 @@
 #include "Drawing/UI/UI.h"
 
 void GameDraw() {
-	__raise BH::moduleManager->OnDraw();
+	BH::moduleManager->OnDraw();
 	Drawing::UI::Draw();
 	Drawing::StatsDisplay::Draw();
 	Drawing::Hook::Draw(Drawing::InGame);
 }
 
 void GameAutomapDraw() {
-	__raise BH::moduleManager->OnAutomapDraw();
+	BH::moduleManager->OnAutomapDraw();
 }
 
 void OOGDraw() {
 	Drawing::Hook::Draw(Drawing::OutOfGame);
-	__raise BH::moduleManager->OnOOGDraw();
+	BH::moduleManager->OnOOGDraw();
 }
  
 void GameLoop() {
-	__raise BH::moduleManager->OnLoop();
+	BH::moduleManager->OnLoop();
 }
 
 DWORD WINAPI GameThread(VOID* lpvoid) {
@@ -35,12 +35,12 @@ DWORD WINAPI GameThread(VOID* lpvoid) {
 	while(true) {
 		if ((*p_D2WIN_FirstControl) && inGame) {
 			inGame = false;
-			__raise BH::moduleManager->OnGameExit();
+			BH::moduleManager->OnGameExit();
 			BH::config->Write();
 			BH::oogDraw->Install();
 		} else if (D2CLIENT_GetPlayerUnit() && !inGame) {
 			inGame = true;
-			__raise BH::moduleManager->OnGameJoin();
+			BH::moduleManager->OnGameJoin();
 			BH::oogDraw->Remove();
 		}
 		Sleep(10);
@@ -60,7 +60,7 @@ LONG WINAPI GameWindowEvent(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 			blockEvent = true;
 		if (Drawing::StatsDisplay::Click(false, mouseX, mouseY))
 			blockEvent = true;
-		__raise BH::moduleManager->OnLeftClick(false, mouseX, mouseY, &blockEvent);
+		BH::moduleManager->OnLeftClick(false, mouseX, mouseY, &blockEvent);
 	}
 
 	if (uMsg == WM_LBUTTONUP) {
@@ -70,7 +70,7 @@ LONG WINAPI GameWindowEvent(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 			blockEvent = true;
 		if (Drawing::StatsDisplay::Click(true, mouseX, mouseY))
 			blockEvent = true;
-		__raise BH::moduleManager->OnLeftClick(true, mouseX, mouseY, &blockEvent);
+		BH::moduleManager->OnLeftClick(true, mouseX, mouseY, &blockEvent);
 	}
 
 	if (uMsg == WM_RBUTTONDOWN) {
@@ -80,7 +80,7 @@ LONG WINAPI GameWindowEvent(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 			blockEvent = true;
 		if (Drawing::StatsDisplay::Click(false, mouseX, mouseY))
 			blockEvent = true;
-		__raise BH::moduleManager->OnRightClick(false, mouseX, mouseY, &blockEvent);
+		BH::moduleManager->OnRightClick(false, mouseX, mouseY, &blockEvent);
 	}
 
 	if (uMsg == WM_RBUTTONUP) {
@@ -90,7 +90,7 @@ LONG WINAPI GameWindowEvent(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 			blockEvent = true;
 		if (Drawing::StatsDisplay::Click(true, mouseX, mouseY))
 			blockEvent = true;
-		__raise BH::moduleManager->OnRightClick(true, mouseX, mouseY, &blockEvent);
+		BH::moduleManager->OnRightClick(true, mouseX, mouseY, &blockEvent);
 	}
 
 	if (!D2CLIENT_GetUIState(0x05)) {
@@ -99,7 +99,7 @@ LONG WINAPI GameWindowEvent(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 				return NULL;
 			if (Drawing::StatsDisplay::KeyClick(false, wParam, lParam))
 				return NULL;
-			__raise BH::moduleManager->OnKey(false, wParam, lParam, &blockEvent);
+			BH::moduleManager->OnKey(false, wParam, lParam, &blockEvent);
 		}
 
 		if (uMsg == WM_KEYUP) {
@@ -107,7 +107,7 @@ LONG WINAPI GameWindowEvent(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 				return NULL;
 			if (Drawing::StatsDisplay::KeyClick(true, wParam, lParam))
 				return NULL;
-			__raise BH::moduleManager->OnKey(true, wParam, lParam, &blockEvent);
+			BH::moduleManager->OnKey(true, wParam, lParam, &blockEvent);
 		}
 	}
 
@@ -116,13 +116,13 @@ LONG WINAPI GameWindowEvent(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 
 BOOL ChatPacketRecv(DWORD dwSize,BYTE* pPacket) {
 	bool blockPacket = false;
-	__raise BH::moduleManager->OnChatPacketRecv(pPacket, &blockPacket);
+	BH::moduleManager->OnChatPacketRecv(pPacket, &blockPacket);
 	return !blockPacket;
 }
 
 BOOL __fastcall RealmPacketRecv(BYTE* pPacket) {
 	bool blockPacket = false;
-	__raise BH::moduleManager->OnRealmPacketRecv(pPacket, &blockPacket);
+	BH::moduleManager->OnRealmPacketRecv(pPacket, &blockPacket);
 	return !blockPacket;
 }
 
@@ -134,11 +134,11 @@ DWORD __fastcall GamePacketRecv(BYTE* pPacket, DWORD dwSize) {
 			char* pName = (char*)pPacket+10;
 			char* pMessage = (char*)pPacket + strlen(pName) + 11;
 			bool blockMessage = false;
-			__raise BH::moduleManager->OnChatMsg(pName, pMessage, true, &blockMessage);
+			BH::moduleManager->OnChatMsg(pName, pMessage, true, &blockMessage);
 			} break;
 	}
 	bool blockPacket = false;
-	__raise BH::moduleManager->OnGamePacketRecv(pPacket, &blockPacket);
+	BH::moduleManager->OnGamePacketRecv(pPacket, &blockPacket);
 	return !blockPacket;
 }
 
@@ -154,7 +154,7 @@ DWORD __fastcall GameInput(wchar_t* wMsg)
 		int len = wcslen(wparam)+1;
 		if(len > 0)
 		{
-			if(!BH::moduleManager->UserInput(token, wparam, true)) hasCmd = false;
+			if(!BH::moduleManager->OnUserInput(token, wparam, true)) hasCmd = false;
 		}
 	}
 
@@ -173,7 +173,7 @@ DWORD __fastcall ChannelInput(wchar_t* wMsg)
 		int len = wcslen(wparam)+1;
 		if(len > 0)
 		{
-			if(!BH::moduleManager->UserInput(token, wparam, false)) hasCmd = false;
+			if(!BH::moduleManager->OnUserInput(token, wparam, false)) hasCmd = false;
 			D2WIN_SetControlText(*p_D2MULTI_ChatInputBox, L"");
 		}
 	}
@@ -184,6 +184,6 @@ DWORD __fastcall ChannelInput(wchar_t* wMsg)
 BOOL __fastcall ChatHandler(char* user, char* msg)
 {
 	bool block = false;
-	__raise BH::moduleManager->OnChatMsg(user, msg, false, &block);
+	BH::moduleManager->OnChatMsg(user, msg, false, &block);
 	return block;
 }

--- a/BH/Modules/Module.cpp
+++ b/BH/Modules/Module.cpp
@@ -22,26 +22,6 @@ void Module::Load() {
 		return;
 
 	// Hook up all the events
-	
-	__hook(&ModuleManager::OnDraw, BH::moduleManager, &Module::OnDraw, this);
-	__hook(&ModuleManager::OnAutomapDraw, BH::moduleManager, &Module::OnAutomapDraw, this);
-	__hook(&ModuleManager::OnOOGDraw, BH::moduleManager, &Module::OnOOGDraw, this);
-
-	__hook(&ModuleManager::OnGameJoin, BH::moduleManager, &Module::OnGameJoin, this);
-	__hook(&ModuleManager::OnGameExit, BH::moduleManager, &Module::OnGameExit, this);
-
-	__hook(&ModuleManager::OnLoop, BH::moduleManager, &Module::OnLoop, this);
-
-	__hook(&ModuleManager::OnLeftClick, BH::moduleManager, &Module::OnLeftClick, this);
-	__hook(&ModuleManager::OnRightClick, BH::moduleManager, &Module::OnRightClick, this);
-	__hook(&ModuleManager::OnKey, BH::moduleManager, &Module::OnKey, this);
-
-	__hook(&ModuleManager::OnChatPacketRecv, BH::moduleManager, &Module::OnChatPacketRecv, this);
-	__hook(&ModuleManager::OnRealmPacketRecv, BH::moduleManager, &Module::OnRealmPacketRecv, this);
-	__hook(&ModuleManager::OnGamePacketRecv, BH::moduleManager, &Module::OnGamePacketRecv, this);
-
-	__hook(&ModuleManager::OnChatMsg, BH::moduleManager, &Module::OnChatMsg, this);
-	__hook(&Module::UserInput, this, &Module::OnUserInput, this);
 
 	active = true;
 	OnLoad();
@@ -50,27 +30,6 @@ void Module::Load() {
 void Module::Unload() {
 	if (!IsActive())
 		return;
-
-	// Unhook all events
-	__unhook(&ModuleManager::OnDraw, BH::moduleManager, &Module::OnDraw, this);
-	__unhook(&ModuleManager::OnAutomapDraw, BH::moduleManager, &Module::OnAutomapDraw, this);
-	__unhook(&ModuleManager::OnOOGDraw, BH::moduleManager, &Module::OnOOGDraw, this);
-
-	__unhook(&ModuleManager::OnGameJoin, BH::moduleManager, &Module::OnGameJoin, this);
-	__unhook(&ModuleManager::OnGameExit, BH::moduleManager, &Module::OnGameExit, this);
-
-	__unhook(&ModuleManager::OnLoop, BH::moduleManager, &Module::OnLoop, this);
-
-	__unhook(&ModuleManager::OnLeftClick, BH::moduleManager, &Module::OnLeftClick, this);
-	__unhook(&ModuleManager::OnRightClick, BH::moduleManager, &Module::OnRightClick, this);
-	__unhook(&ModuleManager::OnKey, BH::moduleManager, &Module::OnKey, this);
-
-	__unhook(&ModuleManager::OnChatPacketRecv, BH::moduleManager, &Module::OnChatPacketRecv, this);
-	__unhook(&ModuleManager::OnRealmPacketRecv, BH::moduleManager, &Module::OnRealmPacketRecv, this);
-	__unhook(&ModuleManager::OnGamePacketRecv, BH::moduleManager, &Module::OnGamePacketRecv, this);
-
-	__unhook(&ModuleManager::OnChatMsg, BH::moduleManager, &Module::OnChatMsg, this);
-	//__unhook(&Module::UserInput, this, &Module::OnUserInput, this);
 
 	active = false;
 	OnUnload();

--- a/BH/Modules/Module.h
+++ b/BH/Modules/Module.h
@@ -50,7 +50,6 @@ class Module {
 		virtual void OnRealmPacketRecv(BYTE* packet, bool* block) {};
 		virtual void OnGamePacketRecv(BYTE* packet, bool* block) {};
 
-		__event void UserInput(const wchar_t* msg, bool fromGame, bool* block);
 		virtual void OnUserInput(const wchar_t* msg, bool fromGame, bool* block) {};
 		virtual void OnChatMsg(const char* user, const char* msg, bool fromGame, bool* block) {};
 };

--- a/BH/Modules/ModuleManager.cpp
+++ b/BH/Modules/ModuleManager.cpp
@@ -77,7 +77,7 @@ void ModuleManager::MpqLoaded() {
 	}
 }
 
-bool ModuleManager::UserInput(wchar_t* module, wchar_t* msg, bool fromGame) {
+bool ModuleManager::OnUserInput(wchar_t* module, wchar_t* msg, bool fromGame) {
 	bool block = false;
 	std::string name;
 	std::wstring modname(module);
@@ -98,8 +98,86 @@ bool ModuleManager::UserInput(wchar_t* module, wchar_t* msg, bool fromGame) {
 
 	for (std::map<std::string, Module*>::iterator it = moduleList.begin(); it != moduleList.end(); ++it) {
 		if (name.compare((*it).first) == 0) {
-			__raise it->second->UserInput(msg, fromGame, &block);
+			it->second->OnUserInput(msg, fromGame, &block);
 		}
 	}
 	return block;
+}
+
+void ModuleManager::OnLoop() {
+	for (auto& module : moduleList) {
+		module.second->OnLoop();
+	}
+}
+
+void ModuleManager::OnGameJoin() {
+	for (auto& module : moduleList) {
+		module.second->OnGameJoin();
+	}
+}
+
+void ModuleManager::OnGameExit() {
+	for (auto& module : moduleList) {
+		module.second->OnGameExit();
+	}
+}
+
+void ModuleManager::OnDraw() {
+	for (auto& module : moduleList) {
+		module.second->OnDraw();
+	}
+}
+
+void ModuleManager::OnAutomapDraw() {
+	for (auto& module : moduleList) {
+		module.second->OnAutomapDraw();
+	}
+}
+
+void ModuleManager::OnOOGDraw() {
+	for (auto& module : moduleList) {
+		module.second->OnOOGDraw();
+	}
+}
+
+void ModuleManager::OnLeftClick(bool up, unsigned int x, unsigned int y, bool* block) {
+	for (auto& module : moduleList) {
+		module.second->OnLeftClick(up, x, y, block);
+	}
+}
+
+void ModuleManager::OnRightClick(bool up, unsigned int x, unsigned int y, bool* block) {
+	for (auto& module : moduleList) {
+		module.second->OnRightClick(up, x, y, block);
+	}
+}
+
+void ModuleManager::OnKey(bool up, BYTE key, LPARAM lParam, bool* block) {
+	for (auto& module : moduleList) {
+		module.second->OnKey(up, key, lParam, block);
+	}
+}
+
+void ModuleManager::OnChatPacketRecv(BYTE* packet, bool* block) {
+	for (auto& module : moduleList) {
+		module.second->OnChatPacketRecv(packet, block);
+	}
+}
+
+void ModuleManager::OnRealmPacketRecv(BYTE* packet, bool* block) {
+	for (auto& module : moduleList) {
+		module.second->OnRealmPacketRecv(packet, block);
+	}
+}
+
+void ModuleManager::OnGamePacketRecv(BYTE* packet, bool* block) {
+	for (auto& module : moduleList) {
+		module.second->OnGamePacketRecv(packet, block);
+	}
+}
+
+void ModuleManager::OnChatMsg(const char* user, const char* msg, bool fromGame, bool* block) {
+	for (auto& module : moduleList) {
+		module.second->OnChatMsg(user, msg, fromGame, block);
+	}
 }

--- a/BH/Modules/ModuleManager.h
+++ b/BH/Modules/ModuleManager.h
@@ -28,24 +28,24 @@ class ModuleManager {
 		void ReloadConfig();
 		void MpqLoaded();
 
-		bool UserInput(wchar_t* module, wchar_t* msg, bool fromGame);
+		bool OnUserInput(wchar_t* module, wchar_t* msg, bool fromGame);
 
-		__event void OnLoop();
+		void OnLoop();
 
-		__event void OnGameJoin();
-		__event void OnGameExit();
+		void OnGameJoin();
+		void OnGameExit();
 
-		__event void OnDraw();
-		__event void OnAutomapDraw();
-		__event void OnOOGDraw();
+		void OnDraw();
+		void OnAutomapDraw();
+		void OnOOGDraw();
 
-		__event void OnLeftClick(bool up, unsigned int x, unsigned int y, bool* block);
-		__event void OnRightClick(bool up, unsigned int x, unsigned int y, bool* block);
-		__event void OnKey(bool up, BYTE key, LPARAM lParam, bool* block);
+		void OnLeftClick(bool up, unsigned int x, unsigned int y, bool* block);
+		void OnRightClick(bool up, unsigned int x, unsigned int y, bool* block);
+		void OnKey(bool up, BYTE key, LPARAM lParam, bool* block);
 
-		__event void OnChatPacketRecv(BYTE* packet, bool* block);
-		__event void OnRealmPacketRecv(BYTE* packet, bool* block);
-		__event void OnGamePacketRecv(BYTE* packet, bool* block);
+		void OnChatPacketRecv(BYTE* packet, bool* block);
+		void OnRealmPacketRecv(BYTE* packet, bool* block);
+		void OnGamePacketRecv(BYTE* packet, bool* block);
 
-		__event void OnChatMsg(const char* user, const char* msg, bool fromGame, bool* block);
+		void OnChatMsg(const char* user, const char* msg, bool fromGame, bool* block);
 };


### PR DESCRIPTION
CMake compile fails to add correct parameters for compilers older than VS2022. This causes the above features to fail.

Refactoring was required to restore compatibility to those compilers.