### PR TITLE
Conform the preprocessor and macros

### DIFF
--- a/BH/D2Ptrs.h
+++ b/BH/D2Ptrs.h
@@ -61,7 +61,7 @@
 #ifdef _DEFINE_PTRS
 #define FUNCPTR(dll, name, callingret, args, ...) \
 	static Offsets f##dll##_##name##_offsets = { __VA_ARGS__ }; \
-	__declspec(naked) callingret dll##_##name##args \
+	__declspec(naked) callingret dll##_##name args \
 	{ \
 		static DWORD f##dll##_##name = NULL; \
 		if(f##dll##_##name == NULL) \
@@ -74,35 +74,35 @@
 	}
 
 #define ASMPTR(dll, name, ...) \
-	DWORD* Asm_##dll##_##name##(VOID) \
+	DWORD* Asm_##dll##_##name(VOID) \
 	{ \
-		static DWORD f##Asm_##dll##_##name = NULL; \
-		if(f##Asm_##dll##_##name## == NULL) \
+		static DWORD fAsm_##dll##_##name = NULL; \
+		if(fAsm_##dll##_##name == NULL) \
 		{ \
-		static Offsets f##Asm_##_##name##_offsets = { __VA_ARGS__ }; \
-		static int address = *(&f##Asm_##_##name##_offsets._113c + D2Version::GetGameVersionID()); \
-		f##Asm_##dll##_##name## = Patch::GetDllOffset(dll, address); \
+		static Offsets fAsm_##name##_offsets = { __VA_ARGS__ }; \
+		static int address = *(&fAsm_##name##_offsets._113c + D2Version::GetGameVersionID()); \
+		fAsm_##dll##_##name = Patch::GetDllOffset(dll, address); \
 		} \
-		return &##f##Asm_##dll##_##name; \
+		return &fAsm_##dll##_##name; \
 	} 
 
 #define VARPTR(dll, name, type, ...) \
-	type** Var_##dll##_##name##(VOID) \
+	type** Var_##dll##_##name(VOID) \
 	{ \
-		static DWORD f##Var_##dll##_##name = NULL; \
-		if(f##Var_##dll##_##name## == NULL) \
+		static DWORD fVar_##dll##_##name = NULL; \
+		if(fVar_##dll##_##name == NULL) \
 		{ \
-		static Offsets f##Var_##_##name##_offsets = { __VA_ARGS__ }; \
-		static int address = *(&f##Var_##_##name##_offsets._113c + D2Version::GetGameVersionID()); \
-		f##Var_##dll##_##name## = Patch::GetDllOffset(dll, address); \
+		static Offsets fVar_##name##_offsets = { __VA_ARGS__ }; \
+		static int address = *(&fVar_##name##_offsets._113c + D2Version::GetGameVersionID()); \
+		fVar_##dll##_##name = Patch::GetDllOffset(dll, address); \
 		} \
-		return (type**)&##f##Var_##dll##_##name; \
+		return (type**)&fVar_##dll##_##name; \
 	} 
 
 #else
-#define FUNCPTR(dll, name, callingret, args, ...) extern callingret dll##_##name##args;
-#define ASMPTR(dll, name, ...) extern DWORD* Asm_##dll##_##name##(VOID); static DWORD dll##_##name = *Asm_##dll##_##name##();
-#define VARPTR(dll, name, type, ...) extern type** Var_##dll##_##name##(VOID); static type* p##_##dll##_##name = (type*)*Var_##dll##_##name##();
+#define FUNCPTR(dll, name, callingret, args, ...) extern callingret dll##_##name args;
+#define ASMPTR(dll, name, ...) extern DWORD* Asm_##dll##_##name(VOID); static DWORD dll##_##name = *Asm_##dll##_##name();
+#define VARPTR(dll, name, type, ...) extern type** Var_##dll##_##name(VOID); static type* p##_##dll##_##name = (type*)*Var_##dll##_##name();
 #endif
 
 FUNCPTR(D2CLIENT, GetQuestInfo, void* __stdcall, (void), 0x45A00, 0x78A80)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,10 +54,9 @@ add_subdirectory(BH)
 add_subdirectory(src)
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE NOMINMAX)
-target_compile_options(${PROJECT_NAME} PRIVATE /permissive)
+target_compile_options(${PROJECT_NAME} PRIVATE /permissive /Zc:preprocessor)
 target_include_directories(${PROJECT_NAME}
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/cpp-lru-cache/include
         ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_link_libraries(${PROJECT_NAME} shlwapi)
-


### PR DESCRIPTION
These changes conform the preprocessor and any previously nonconformant macros. This allows for the use of `__VA_OPT__`. D2Ptrs macros have been modified for conformance, without introducing behavioral changes.