### PR TITLE
Add new DLL handle interface

### DIFF
--- a/BH/Patch.cpp
+++ b/BH/Patch.cpp
@@ -7,10 +7,165 @@
 #include <vector>
 
 #include "D2Version.h"
+#include "bh/common/logging/logger.hpp"
+#include "bh/d2/dll/dll.hpp"
+#include "bh/d2/dll/handle.hpp"
+#include "bh/d2/dll/path.hpp"
+#include "bh/global/file_logger.hpp"
+
+namespace {
+
+using ::bh::common::logging::Logger;
+using ::bh::d2::dll::GetAbsolutePath;
+using ::bh::d2::dll::GetHandle;
+using ::bh::global::GetFileLogger;
+
+using NewDll = ::bh::d2::Dll;
+
+static Logger& GetLogger() {
+	static Logger& logger = GetFileLogger(__FILEW__);
+	return logger;
+}
+
+static NewDll ToNewDllEnum(Dll oldDll) {
+	switch (oldDll) {
+		case Dll::BNCLIENT: {
+			return NewDll::kBnClient;
+		}
+
+		case Dll::D2CLIENT: {
+			return NewDll::kD2Client;
+		}
+
+		case Dll::D2CMP: {
+			return NewDll::kD2Cmp;
+		}
+
+		case Dll::D2COMMON: {
+			return NewDll::kD2Common;
+		}
+
+		case Dll::D2GAME: {
+			return NewDll::kD2Game;
+		}
+
+		case Dll::D2GFX: {
+			return NewDll::kD2Gfx;
+		}
+
+		case Dll::D2LANG: {
+			return NewDll::kD2Lang;
+		}
+
+		case Dll::D2LAUNCH: {
+			return NewDll::kD2Launch;
+		}
+
+		case Dll::D2MCPCLIENT: {
+			return NewDll::kD2McpClient;
+		}
+
+		case Dll::D2MULTI: {
+			return NewDll::kD2Multi;
+		}
+
+		case Dll::D2NET: {
+			return NewDll::kD2Net;
+		}
+
+		case Dll::D2WIN: {
+			return NewDll::kD2Win;
+		}
+
+		case Dll::FOG: {
+			return NewDll::kFog;
+		}
+
+		case Dll::STORM: {
+			return NewDll::kStorm;
+		}
+	}
+
+	// This should never happen.
+	GetLogger().Fatal(
+			__LINE__,
+			"Unhandled Dll with value {:d}.",
+			static_cast<int>(oldDll));
+	return static_cast<NewDll>(-1);
+}
+
+static Dll ToOldDllEnum(NewDll newDll) {
+	switch (newDll) {
+		case NewDll::kBnClient: {
+			return Dll::BNCLIENT;
+		}
+
+		case NewDll::kD2Client: {
+			return Dll::D2CLIENT;
+		}
+
+		case NewDll::kD2Cmp: {
+			return Dll::D2CMP;
+		}
+
+		case NewDll::kD2Common: {
+			return Dll::D2COMMON;
+		}
+
+		case NewDll::kD2Game: {
+			return Dll::D2GAME;
+		}
+
+		case NewDll::kD2Gfx: {
+			return Dll::D2GFX;
+		}
+
+		case NewDll::kD2Lang: {
+			return Dll::D2LANG;
+		}
+
+		case NewDll::kD2Launch: {
+			return Dll::D2LAUNCH;
+		}
+
+		case NewDll::kD2McpClient: {
+			return Dll::D2MCPCLIENT;
+		}
+
+		case NewDll::kD2Multi: {
+			return Dll::D2MULTI;
+		}
+
+		case NewDll::kD2Net: {
+			return Dll::D2NET;
+		}
+
+		case NewDll::kD2Win: {
+			return Dll::D2WIN;
+		}
+
+		case NewDll::kFog: {
+			return Dll::FOG;
+		}
+
+		case NewDll::kStorm: {
+			return Dll::STORM;
+		}
+	}
+
+	// This should never happen.
+	GetLogger().Fatal(
+			__LINE__,
+			"Unhandled Dll with value {:d}.",
+			static_cast<int>(newDll));
+	return static_cast<Dll>(-1);
+}
+
+}  // namespace
 
 std::vector<Patch*> Patch::Patches;
 
-Patch::Patch(PatchType type, Dll dll, Offsets offsets, int function, int length) 
+Patch::Patch(PatchType type, Dll dll, Offsets offsets, int function, int length)
 : type(type), dll(dll), offsets(offsets), function(function), length(length) {
 	oldCode = new BYTE[length];
 	injected = false;
@@ -18,20 +173,18 @@ Patch::Patch(PatchType type, Dll dll, Offsets offsets, int function, int length)
 }
 
 int Patch::GetDllOffset(Dll dll, int offset) {
-	const char* szDlls[] = {"D2CLIENT.dll", "D2COMMON.dll", "D2GFX.dll", "D2LANG.dll",
-							"D2WIN.dll", "D2NET.dll", "D2GAME.dll", "D2LAUNCH.dll",
-							"FOG.dll", "BNCLIENT.dll", "STORM.dll", "D2CMP.dll", "D2MULTI.dll", "D2MCPCLIENT.dll", "D2CMP.dll"};
 	//Attempt to get the module of the given DLL
-	HMODULE hModule = GetModuleHandle(szDlls[dll]);
-
-	//If DLL hasn't been loaded, then load it up!
-	if (!hModule) {
-		hModule = LoadLibrary(szDlls[dll]);
-	}
+	NewDll newDll = ToNewDllEnum(dll);
+	HMODULE hModule = GetHandle(newDll);
 
 	//If the DLL isn't there, or failed to load, return.
-	if (!hModule)
+	if (!hModule) {
+		GetLogger().Fatal(
+				__LINE__,
+				"Unable to load DLL with value {}",
+				static_cast<int>(newDll));
 		return false;
+	}
 
 	//Check if it is an ordinal, if so, get the proper address.
 	if (offset  < 0)
@@ -69,7 +222,7 @@ bool Patch::Install() {
 
 	//Read the old code to allow proper patch removal
 	ReadProcessMemory(GetCurrentProcess(), (void*)address, oldCode, length, NULL);
-	
+
 	//Set the code with all NOPs by default
 	if (type == 0x68) {
 		memset(code, 0x00, length);

--- a/BH/Patch.cpp
+++ b/BH/Patch.cpp
@@ -10,13 +10,11 @@
 #include "bh/common/logging/logger.hpp"
 #include "bh/d2/dll/dll.hpp"
 #include "bh/d2/dll/handle.hpp"
-#include "bh/d2/dll/path.hpp"
 #include "bh/global/file_logger.hpp"
 
 namespace {
 
 using ::bh::common::logging::Logger;
-using ::bh::d2::dll::GetAbsolutePath;
 using ::bh::d2::dll::GetHandle;
 using ::bh::global::GetFileLogger;
 

--- a/src/bh/d2/dll/CMakeLists.txt
+++ b/src/bh/d2/dll/CMakeLists.txt
@@ -17,5 +17,10 @@
 # License along with this program.  If not, see
 # <http://www.gnu.org/licenses/>.
 
-add_subdirectory("dll")
-add_subdirectory("game")
+target_sources(${PROJECT_NAME}
+    PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/handle.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/handle.hpp"
+)
+
+add_subdirectory("internal")

--- a/src/bh/d2/dll/dll.hpp
+++ b/src/bh/d2/dll/dll.hpp
@@ -1,0 +1,87 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef BH_D2_DLL_HPP_
+#define BH_D2_DLL_HPP_
+
+#include <string_view>
+
+namespace bh::d2 {
+
+enum class Dll {
+  kUnspecified = 0,
+
+  /*
+   * Only dynamic-link libraries that bundle with Diablo II are
+   * permitted to be added.
+   *
+   * The following libraries are products of other entities. Do not
+   * add any of these files:
+   * binkw32.dll, glide3x.dll, ijl11.dll, SmackW32.dll
+   */
+
+  kBnClient,
+  kD2Client,
+  kD2Cmp,
+  kD2Common,
+  kD2DDraw,
+  kD2Direct3d,
+  kD2Game,
+  kD2Gdi,
+  kD2Gfx,
+  kD2Glide,
+  kD2Lang,
+  kD2Launch,
+  kD2McpClient,
+  kD2Multi,
+  kD2Net,
+  kD2Sound,
+  kD2Win,
+  kFog,
+  kStorm,
+};
+
+inline constexpr auto kDlls = std::to_array<Dll>({
+    Dll::kBnClient,
+    Dll::kD2Client,
+    Dll::kD2Cmp,
+    Dll::kD2Common,
+    Dll::kD2DDraw,
+    Dll::kD2Direct3d,
+    Dll::kD2Game,
+    Dll::kD2Gdi,
+    Dll::kD2Gfx,
+    Dll::kD2Glide,
+    Dll::kD2Lang,
+    Dll::kD2Launch,
+    Dll::kD2McpClient,
+    Dll::kD2Multi,
+    Dll::kD2Net,
+    Dll::kD2Sound,
+    Dll::kD2Win,
+    Dll::kFog,
+    Dll::kStorm,
+});
+static_assert(std::ranges::is_sorted(kDlls));
+
+}  // namespace bh::d2
+
+#endif  // BH_D2_DLL_HPP_

--- a/src/bh/d2/dll/handle.cpp
+++ b/src/bh/d2/dll/handle.cpp
@@ -1,0 +1,110 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "bh/d2/dll/handle.hpp"
+
+#include <windows.h>
+
+#include <array>
+#include <algorithm>
+#include <unordered_map>
+#include <utility>
+
+#include "bh/common/logging/logger.hpp"
+#include "bh/d2/dll/dll.hpp"
+#include "bh/d2/dll/internal/relative_path.hpp"
+#include "bh/global/file_logger.hpp"
+
+namespace bh::d2::dll {
+namespace {
+
+using ::bh::common::logging::Logger;
+using ::bh::d2::Dll;
+using ::bh::global::GetFileLogger;
+
+static Logger& GetLogger() {
+  static Logger& logger = GetFileLogger(__FILEW__);
+  return logger;
+}
+
+static std::array<std::pair<Dll, HMODULE>, kDlls.size()> InitHandlesTable() {
+  /*
+   * The handles table is not initialized with all library handles,
+   * because certain ones require a specific condition to be loaded
+   * (for example, D2Glide.dll).
+   */
+  std::array<std::pair<Dll, HMODULE>, kDlls.size()> handles_table = { };
+  std::ranges::transform(
+      kDlls,
+      handles_table.begin(),
+      [] (Dll dll) {
+        return std::pair<Dll, HMODULE>(dll, nullptr);
+      });
+
+  return handles_table;
+}
+
+static HMODULE InitModule(Dll dll) {
+  std::wstring_view relative_path = internal::GetRelativePath(dll);
+  HMODULE handle = LoadLibraryW(relative_path.data());
+  if (handle == nullptr) {
+    GetLogger().Fatal(
+        __LINE__,
+        "LoadLibraryW failed with error code 0x{:X}.",
+        GetLastError());
+    return nullptr;
+  }
+
+  return handle;
+}
+
+}  // namespace
+
+HMODULE GetHandle(Dll dll) {
+  static std::array handles_table = InitHandlesTable();
+  auto search_result =
+      std::ranges::equal_range(
+          handles_table,
+          dll,
+          {},
+          [] (const auto& entry) {
+            return entry.first;
+          });
+
+  // No result, but this should never happen.
+  if (search_result.empty()) {
+    GetLogger().Fatal(
+        __LINE__,
+        "Unhandled Dll with value {:d}",
+        static_cast<int>(dll));
+    return nullptr;
+  }
+
+  // Load the module to the table, if it isn't there.
+  HMODULE& handle = search_result.front().second;
+  if (handle == nullptr) {
+    handle = InitModule(dll);
+  }
+
+  return handle;
+}
+
+}  // namespace bh::d2::dll

--- a/src/bh/d2/dll/handle.hpp
+++ b/src/bh/d2/dll/handle.hpp
@@ -1,0 +1,35 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef BH_D2_DLL_HANDLE_HPP_
+#define BH_D2_DLL_HANDLE_HPP_
+
+#include <windows.h>
+
+#include "bh/d2/dll/dll.hpp"
+
+namespace bh::d2::dll {
+
+HMODULE GetHandle(::bh::d2::Dll dll);
+
+}  // namespace bh::d2::dll
+
+#endif  // BH_D2_DLL_HANDLE_HPP_

--- a/src/bh/d2/dll/internal/CMakeLists.txt
+++ b/src/bh/d2/dll/internal/CMakeLists.txt
@@ -17,5 +17,8 @@
 # License along with this program.  If not, see
 # <http://www.gnu.org/licenses/>.
 
-add_subdirectory("dll")
-add_subdirectory("game")
+target_sources(${PROJECT_NAME}
+    PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/relative_path.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/relative_path.hpp"
+)

--- a/src/bh/d2/dll/internal/relative_path.cpp
+++ b/src/bh/d2/dll/internal/relative_path.cpp
@@ -1,0 +1,150 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "bh/d2/dll/internal/relative_path.hpp"
+
+#include <string_view>
+
+#include "bh/common/logging/logger.hpp"
+#include "bh/d2/dll/dll.hpp"
+#include "bh/global/file_logger.hpp"
+
+namespace bh::d2::dll::internal {
+namespace {
+
+using ::bh::common::logging::Logger;
+using ::bh::d2::Dll;
+using ::bh::global::GetFileLogger;
+
+static Logger& GetLogger() {
+  static Logger& logger = GetFileLogger(__FILEW__);
+  return logger;
+}
+
+}  // namespace
+
+std::wstring_view GetRelativePath(Dll dll) {
+  switch (dll) {
+    case Dll::kBnClient: {
+      static constexpr std::wstring_view kPath = L"BnClient.dll";
+      return kPath;
+    }
+
+    case Dll::kD2Client: {
+      static constexpr std::wstring_view kPath = L"D2Client.dll";
+      return kPath;
+    }
+
+    case Dll::kD2Cmp: {
+      static constexpr std::wstring_view kPath = L"D2Cmp.dll";
+      return kPath;
+    }
+
+    case Dll::kD2Common: {
+      static constexpr std::wstring_view kPath = L"D2Common.dll";
+      return kPath;
+    }
+
+    case Dll::kD2DDraw: {
+      static constexpr std::wstring_view kPath = L"D2DDraw.dll";
+      return kPath;
+    }
+
+    case Dll::kD2Direct3d: {
+      static constexpr std::wstring_view kPath = L"D2Direct3d.dll";
+      return kPath;
+    }
+
+    case Dll::kD2Game: {
+      static constexpr std::wstring_view kPath = L"D2Game.dll";
+      return kPath;
+    }
+
+    case Dll::kD2Gdi: {
+      static constexpr std::wstring_view kPath = L"D2Gdi.dll";
+      return kPath;
+    }
+
+    case Dll::kD2Gfx: {
+      static constexpr std::wstring_view kPath = L"D2Gfx.dll";
+      return kPath;
+    }
+
+    case Dll::kD2Glide: {
+      static constexpr std::wstring_view kPath = L"D2Glide.dll";
+      return kPath;
+    }
+
+    case Dll::kD2Lang: {
+      static constexpr std::wstring_view kPath = L"D2Lang.dll";
+      return kPath;
+    }
+
+    case Dll::kD2Launch: {
+      static constexpr std::wstring_view kPath = L"D2Launch.dll";
+      return kPath;
+    }
+
+    case Dll::kD2McpClient: {
+      static constexpr std::wstring_view kPath = L"D2McpClient.dll";
+      return kPath;
+    }
+
+    case Dll::kD2Multi: {
+      static constexpr std::wstring_view kPath = L"D2Multi.dll";
+      return kPath;
+    }
+
+    case Dll::kD2Net: {
+      static constexpr std::wstring_view kPath = L"D2Net.dll";
+      return kPath;
+    }
+
+    case Dll::kD2Sound: {
+      static constexpr std::wstring_view kPath = L"D2Sound.dll";
+      return kPath;
+    }
+
+    case Dll::kD2Win: {
+      static constexpr std::wstring_view kPath = L"D2Win.dll";
+      return kPath;
+    }
+
+    case Dll::kFog: {
+      static constexpr std::wstring_view kPath = L"Fog.dll";
+      return kPath;
+    }
+
+    case Dll::kStorm: {
+      static constexpr std::wstring_view kPath = L"Storm.dll";
+      return kPath;
+    }
+  }
+
+  // This should never happen.
+  GetLogger().Fatal(
+      __LINE__,
+      "Unhandled Dll with value {:d}.",
+      static_cast<int>(dll));
+  return L"";
+}
+
+}  // namespace bh::d2::dll::internal

--- a/src/bh/d2/dll/internal/relative_path.hpp
+++ b/src/bh/d2/dll/internal/relative_path.hpp
@@ -1,0 +1,35 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef BH_D2_DLL_INTERNAL_RELATIVE_PATH_HPP_
+#define BH_D2_DLL_INTERNAL_RELATIVE_PATH_HPP_
+
+#include <string_view>
+
+#include "bh/d2/dll/dll.hpp"
+
+namespace bh::d2::dll::internal {
+
+std::wstring_view GetRelativePath(bh::d2::Dll dll);
+
+}  // namespace bh::d2::dll::internal
+
+#endif  // BH_D2_DLL_INTERNAL_RELATIVE_PATH_HPP_


### PR DESCRIPTION
These changes implement a new interface to get the DLL handles of the Diablo II process. Existing code had this functionality coupled with the Patch code.