### PR TITLE
Add new address interface

### DIFF
--- a/BH/D2Ptrs.h
+++ b/BH/D2Ptrs.h
@@ -53,53 +53,10 @@
 #include "D2DataTables.h"
 #include "D2Structs.h"
 #include "D2Stubs.h"
-#include "D2Version.h"
-#include "Patch.h"
 
 // Macros adapted from lord2800's macros.
 
-#ifdef _DEFINE_PTRS
-#define FUNCPTR(dll, name, callingret, args, ...) \
-	static Offsets f##dll##_##name##_offsets = { __VA_ARGS__ }; \
-	__declspec(naked) callingret dll##_##name args \
-	{ \
-		static DWORD f##dll##_##name = NULL; \
-		if(f##dll##_##name == NULL) \
-		{ \
-		__asm { pushad } \
-		f##dll##_##name = Patch::GetDllOffset(dll, *(&f##dll##_##name##_offsets._113c + D2Version::GetGameVersionID())); \
-		__asm { popad } \
-		} \
-		__asm jmp [f##dll##_##name] \
-	}
-
-#define ASMPTR(dll, name, ...) \
-	DWORD* Asm_##dll##_##name(VOID) \
-	{ \
-		static DWORD fAsm_##dll##_##name = NULL; \
-		if(fAsm_##dll##_##name == NULL) \
-		{ \
-		static Offsets fAsm_##name##_offsets = { __VA_ARGS__ }; \
-		static int address = *(&fAsm_##name##_offsets._113c + D2Version::GetGameVersionID()); \
-		fAsm_##dll##_##name = Patch::GetDllOffset(dll, address); \
-		} \
-		return &fAsm_##dll##_##name; \
-	} 
-
-#define VARPTR(dll, name, type, ...) \
-	type** Var_##dll##_##name(VOID) \
-	{ \
-		static DWORD fVar_##dll##_##name = NULL; \
-		if(fVar_##dll##_##name == NULL) \
-		{ \
-		static Offsets fVar_##name##_offsets = { __VA_ARGS__ }; \
-		static int address = *(&fVar_##name##_offsets._113c + D2Version::GetGameVersionID()); \
-		fVar_##dll##_##name = Patch::GetDllOffset(dll, address); \
-		} \
-		return (type**)&fVar_##dll##_##name; \
-	} 
-
-#else
+#ifndef _DEFINE_PTRS
 #define FUNCPTR(dll, name, callingret, args, ...) extern callingret dll##_##name args;
 #define ASMPTR(dll, name, ...) extern DWORD* Asm_##dll##_##name(VOID); static DWORD dll##_##name = *Asm_##dll##_##name();
 #define VARPTR(dll, name, type, ...) extern type** Var_##dll##_##name(VOID); static type* p##_##dll##_##name = (type*)*Var_##dll##_##name();

--- a/BH/D2Version.cpp
+++ b/BH/D2Version.cpp
@@ -17,20 +17,6 @@ using NewVersion = exe::version::Version;
 
 using ::bh::common::string_util::wide::ToUtf8;
 
-static VersionID ToOldVersionEnum(NewVersion newVersion) {
-	switch (newVersion) {
-		case NewVersion::k1_13c: {
-			return VersionID::VERSION_113c;
-		}
-
-		case NewVersion::k1_13d: {
-			return VersionID::VERSION_113d;
-		}
-	}
-
-	return VersionID::INVALID;
-}
-
 }  // namespace
 
 VersionID D2Version::GetGameVersionID() {
@@ -43,4 +29,32 @@ std::string D2Version::GetHumanReadableVersion() {
 					exe::version::GetDisplayName(
 							exe::version::GetRunning()));
 	return utf8DisplayName;
+}
+
+NewVersion D2Version::ToNewVersionEnum(VersionID oldVersion) {
+	switch (oldVersion) {
+		case VersionID::VERSION_113c: {
+			return NewVersion::k1_13c;
+		}
+
+		case VersionID::VERSION_113d: {
+			return NewVersion::k1_13d;
+		}
+	}
+
+	return NewVersion::kUnspecified;
+}
+
+VersionID D2Version::ToOldVersionEnum(NewVersion newVersion) {
+	switch (newVersion) {
+		case NewVersion::k1_13c: {
+			return VersionID::VERSION_113c;
+		}
+
+		case NewVersion::k1_13d: {
+			return VersionID::VERSION_113d;
+		}
+	}
+
+	return VersionID::INVALID;
 }

--- a/BH/D2Version.h
+++ b/BH/D2Version.h
@@ -5,6 +5,8 @@
 
 #include <string>
 
+#include "bh/d2/exe/version.hpp"
+
 enum VersionID {
     INVALID = -1,
     VERSION_113c = 0,
@@ -17,6 +19,9 @@ namespace D2Version {
 
     [[deprecated("Use bh::d2::exe::version::GetDisplayName")]]
     std::string GetHumanReadableVersion();
+
+    ::bh::d2::exe::version::Version ToNewVersionEnum(VersionID oldVersion);
+    VersionID ToOldVersionEnum(::bh::d2::exe::version::Version newVersion);
 };
 
 #endif

--- a/BH/Patch.cpp
+++ b/BH/Patch.cpp
@@ -25,140 +25,6 @@ static Logger& GetLogger() {
 	return logger;
 }
 
-static NewDll ToNewDllEnum(Dll oldDll) {
-	switch (oldDll) {
-		case Dll::BNCLIENT: {
-			return NewDll::kBnClient;
-		}
-
-		case Dll::D2CLIENT: {
-			return NewDll::kD2Client;
-		}
-
-		case Dll::D2CMP: {
-			return NewDll::kD2Cmp;
-		}
-
-		case Dll::D2COMMON: {
-			return NewDll::kD2Common;
-		}
-
-		case Dll::D2GAME: {
-			return NewDll::kD2Game;
-		}
-
-		case Dll::D2GFX: {
-			return NewDll::kD2Gfx;
-		}
-
-		case Dll::D2LANG: {
-			return NewDll::kD2Lang;
-		}
-
-		case Dll::D2LAUNCH: {
-			return NewDll::kD2Launch;
-		}
-
-		case Dll::D2MCPCLIENT: {
-			return NewDll::kD2McpClient;
-		}
-
-		case Dll::D2MULTI: {
-			return NewDll::kD2Multi;
-		}
-
-		case Dll::D2NET: {
-			return NewDll::kD2Net;
-		}
-
-		case Dll::D2WIN: {
-			return NewDll::kD2Win;
-		}
-
-		case Dll::FOG: {
-			return NewDll::kFog;
-		}
-
-		case Dll::STORM: {
-			return NewDll::kStorm;
-		}
-	}
-
-	// This should never happen.
-	GetLogger().Fatal(
-			__LINE__,
-			"Unhandled Dll with value {:d}.",
-			static_cast<int>(oldDll));
-	return static_cast<NewDll>(-1);
-}
-
-static Dll ToOldDllEnum(NewDll newDll) {
-	switch (newDll) {
-		case NewDll::kBnClient: {
-			return Dll::BNCLIENT;
-		}
-
-		case NewDll::kD2Client: {
-			return Dll::D2CLIENT;
-		}
-
-		case NewDll::kD2Cmp: {
-			return Dll::D2CMP;
-		}
-
-		case NewDll::kD2Common: {
-			return Dll::D2COMMON;
-		}
-
-		case NewDll::kD2Game: {
-			return Dll::D2GAME;
-		}
-
-		case NewDll::kD2Gfx: {
-			return Dll::D2GFX;
-		}
-
-		case NewDll::kD2Lang: {
-			return Dll::D2LANG;
-		}
-
-		case NewDll::kD2Launch: {
-			return Dll::D2LAUNCH;
-		}
-
-		case NewDll::kD2McpClient: {
-			return Dll::D2MCPCLIENT;
-		}
-
-		case NewDll::kD2Multi: {
-			return Dll::D2MULTI;
-		}
-
-		case NewDll::kD2Net: {
-			return Dll::D2NET;
-		}
-
-		case NewDll::kD2Win: {
-			return Dll::D2WIN;
-		}
-
-		case NewDll::kFog: {
-			return Dll::FOG;
-		}
-
-		case NewDll::kStorm: {
-			return Dll::STORM;
-		}
-	}
-
-	// This should never happen.
-	GetLogger().Fatal(
-			__LINE__,
-			"Unhandled Dll with value {:d}.",
-			static_cast<int>(newDll));
-	return static_cast<Dll>(-1);
-}
-
 }  // namespace
 
 std::vector<Patch*> Patch::Patches;
@@ -273,4 +139,138 @@ bool Patch::Remove() {
 	injected = false;
 
 	return true;
+}
+
+NewDll ToNewDllEnum(Dll oldDll) {
+	switch (oldDll) {
+		case Dll::BNCLIENT: {
+			return NewDll::kBnClient;
+		}
+
+		case Dll::D2CLIENT: {
+			return NewDll::kD2Client;
+		}
+
+		case Dll::D2CMP: {
+			return NewDll::kD2Cmp;
+		}
+
+		case Dll::D2COMMON: {
+			return NewDll::kD2Common;
+		}
+
+		case Dll::D2GAME: {
+			return NewDll::kD2Game;
+		}
+
+		case Dll::D2GFX: {
+			return NewDll::kD2Gfx;
+		}
+
+		case Dll::D2LANG: {
+			return NewDll::kD2Lang;
+		}
+
+		case Dll::D2LAUNCH: {
+			return NewDll::kD2Launch;
+		}
+
+		case Dll::D2MCPCLIENT: {
+			return NewDll::kD2McpClient;
+		}
+
+		case Dll::D2MULTI: {
+			return NewDll::kD2Multi;
+		}
+
+		case Dll::D2NET: {
+			return NewDll::kD2Net;
+		}
+
+		case Dll::D2WIN: {
+			return NewDll::kD2Win;
+		}
+
+		case Dll::FOG: {
+			return NewDll::kFog;
+		}
+
+		case Dll::STORM: {
+			return NewDll::kStorm;
+		}
+	}
+
+	// This should never happen.
+	GetLogger().Fatal(
+			__LINE__,
+			"Unhandled Dll with value {:d}.",
+			static_cast<int>(oldDll));
+	return static_cast<NewDll>(-1);
+}
+
+Dll ToOldDllEnum(NewDll newDll) {
+	switch (newDll) {
+		case NewDll::kBnClient: {
+			return Dll::BNCLIENT;
+		}
+
+		case NewDll::kD2Client: {
+			return Dll::D2CLIENT;
+		}
+
+		case NewDll::kD2Cmp: {
+			return Dll::D2CMP;
+		}
+
+		case NewDll::kD2Common: {
+			return Dll::D2COMMON;
+		}
+
+		case NewDll::kD2Game: {
+			return Dll::D2GAME;
+		}
+
+		case NewDll::kD2Gfx: {
+			return Dll::D2GFX;
+		}
+
+		case NewDll::kD2Lang: {
+			return Dll::D2LANG;
+		}
+
+		case NewDll::kD2Launch: {
+			return Dll::D2LAUNCH;
+		}
+
+		case NewDll::kD2McpClient: {
+			return Dll::D2MCPCLIENT;
+		}
+
+		case NewDll::kD2Multi: {
+			return Dll::D2MULTI;
+		}
+
+		case NewDll::kD2Net: {
+			return Dll::D2NET;
+		}
+
+		case NewDll::kD2Win: {
+			return Dll::D2WIN;
+		}
+
+		case NewDll::kFog: {
+			return Dll::FOG;
+		}
+
+		case NewDll::kStorm: {
+			return Dll::STORM;
+		}
+	}
+
+	// This should never happen.
+	GetLogger().Fatal(
+			__LINE__,
+			"Unhandled Dll with value {:d}.",
+			static_cast<int>(newDll));
+	return static_cast<Dll>(-1);
 }

--- a/BH/Patch.h
+++ b/BH/Patch.h
@@ -5,9 +5,13 @@
 #include <string>
 #include <vector>
 
-class Patch;
+#include "bh/d2/dll/dll.hpp"
 
 enum Dll { D2CLIENT=0,D2COMMON,D2GFX,D2LANG,D2WIN,D2NET,D2GAME,D2LAUNCH,FOG,BNCLIENT, STORM, D2CMP, D2MULTI, D2MCPCLIENT};
+
+::bh::d2::dll::Dll ToNewDllEnum(Dll oldDll);
+Dll ToOldDllEnum(::bh::d2::dll::Dll newDll);
+
 enum PatchType { Jump=0xE9, Call=0xE8, NOP=0x90, Push=0x6A };
 
 struct Offsets {

--- a/src/bh/d2/dll/CMakeLists.txt
+++ b/src/bh/d2/dll/CMakeLists.txt
@@ -19,6 +19,9 @@
 
 target_sources(${PROJECT_NAME}
     PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/address.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/address.hpp"
+
         "${CMAKE_CURRENT_SOURCE_DIR}/handle.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/handle.hpp"
 

--- a/src/bh/d2/dll/address.cpp
+++ b/src/bh/d2/dll/address.cpp
@@ -1,0 +1,69 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "bh/d2/dll/address.hpp"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <windows.h>
+
+#include "bh/common/logging/logger.hpp"
+#include "bh/d2/dll/dll.hpp"
+#include "bh/d2/dll/handle.hpp"
+#include "bh/global/file_logger.hpp"
+
+namespace bh::d2::dll {
+namespace {
+
+using ::bh::common::logging::Logger;
+using ::bh::global::GetFileLogger;
+
+static Logger& GetLogger() {
+  static Logger& logger = GetFileLogger(__FILEW__);
+  return logger;
+}
+
+}  // namespace
+
+void* GetAddress(Dll dll, Offset offset) {
+  HMODULE module_handle = GetHandle(dll);
+  unsigned char* address = reinterpret_cast<unsigned char*>(module_handle);
+  return address + offset;
+}
+
+void* GetAddress(Dll dll, Ordinal ordinal) {
+  HMODULE module_handle = GetHandle(dll);
+  FARPROC proc_address =
+      GetProcAddress(module_handle, static_cast<LPCSTR>(ordinal));
+  if (proc_address == nullptr) {
+    GetLogger().Fatal(
+        __LINE__,
+        "GetProcAddress(0x{:X}, {}) failed with error code 0x{:X}.",
+        reinterpret_cast<uintptr_t>(module_handle),
+        static_cast<unsigned short>(ordinal),
+        GetLastError());
+    return nullptr;
+  }
+
+  return reinterpret_cast<void*>(proc_address);
+}
+
+}  // namespace bh::d2::dll

--- a/src/bh/d2/dll/address.hpp
+++ b/src/bh/d2/dll/address.hpp
@@ -1,0 +1,68 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef BH_D2_DLL_ADDRESS_HPP_
+#define BH_D2_DLL_ADDRESS_HPP_
+
+#include <stddef.h>
+
+#include "bh/d2/dll/dll.hpp"
+
+namespace bh::d2::dll {
+
+struct Offset {
+  explicit constexpr Offset(ptrdiff_t offset) noexcept : offset(offset) {}
+
+  constexpr operator ptrdiff_t() const noexcept {
+    return offset;
+  }
+
+  ptrdiff_t offset;
+};
+
+struct Ordinal {
+  explicit constexpr Ordinal(unsigned short ordinal) noexcept
+      : ordinal(ordinal) {}
+
+  constexpr operator unsigned short() const noexcept {
+    return ordinal;
+  }
+
+  explicit operator const char*() const noexcept {
+    return reinterpret_cast<const char*>(ordinal);
+  }
+
+  unsigned short ordinal;
+};
+
+/**
+ * Get a DLL address with an offset.
+ */
+void* GetAddress(Dll dll, Offset offset);
+
+/**
+ * Get a DLL address with an ordinal.
+ */
+void* GetAddress(Dll dll, Ordinal ordinal);
+
+}  // namespace bh::d2::dll
+
+#endif  // BH_D2_DLL_ADDRESS_HPP_


### PR DESCRIPTION
These changes add a new interface to get an address from a DLL using and offset or ordinal. Old code cannot be changed due to non-conformant behavior resulting in crashes.