### PR TITLE
Replace Storm in D2Ptrs

### DIFF
--- a/BH/D2Ptrs.h
+++ b/BH/D2Ptrs.h
@@ -492,7 +492,6 @@ FUNCPTR(D2MCPCLIENT, ParseGameListPacket, VOID __fastcall, (BYTE* pPacket), 0x6E
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
 FUNCPTR(STORM, SFileOpenFileEx, bool __stdcall, (HANDLE hMpq, const char* szFileName, DWORD dwSearchScope, HANDLE* phFile), -268, -268)
-FUNCPTR(STORM, SFileGetFileSize, bool __stdcall, (HANDLE hFile, DWORD* pdwFileSizeHigh), -265, -265)
 FUNCPTR(STORM, SFileReadFile, bool __stdcall, (HANDLE hFile, VOID* lpBuffer, DWORD dwToRead, DWORD* pdwRead, LPOVERLAPPED lpOverlapped), -269, -269)
 
 #undef FUNCPTR

--- a/BH/D2Ptrs.h
+++ b/BH/D2Ptrs.h
@@ -491,7 +491,6 @@ FUNCPTR(D2MCPCLIENT, ParseGameListPacket, VOID __fastcall, (BYTE* pPacket), 0x6E
 // Storm Functions
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
-FUNCPTR(STORM, SFileCloseArchive, bool __stdcall, (HANDLE hMpq), -252, -252)
 FUNCPTR(STORM, SFileOpenFileEx, bool __stdcall, (HANDLE hMpq, const char* szFileName, DWORD dwSearchScope, HANDLE* phFile), -268, -268)
 FUNCPTR(STORM, SFileGetFileSize, bool __stdcall, (HANDLE hFile, DWORD* pdwFileSizeHigh), -265, -265)
 FUNCPTR(STORM, SFileReadFile, bool __stdcall, (HANDLE hFile, VOID* lpBuffer, DWORD dwToRead, DWORD* pdwRead, LPOVERLAPPED lpOverlapped), -269, -269)

--- a/BH/D2Ptrs.h
+++ b/BH/D2Ptrs.h
@@ -495,7 +495,6 @@ FUNCPTR(STORM, SFileCloseArchive, bool __stdcall, (HANDLE hMpq), -252, -252)
 FUNCPTR(STORM, SFileOpenFileEx, bool __stdcall, (HANDLE hMpq, const char* szFileName, DWORD dwSearchScope, HANDLE* phFile), -268, -268)
 FUNCPTR(STORM, SFileGetFileSize, bool __stdcall, (HANDLE hFile, DWORD* pdwFileSizeHigh), -265, -265)
 FUNCPTR(STORM, SFileReadFile, bool __stdcall, (HANDLE hFile, VOID* lpBuffer, DWORD dwToRead, DWORD* pdwRead, LPOVERLAPPED lpOverlapped), -269, -269)
-FUNCPTR(STORM, SFileCloseFile, bool __stdcall, (HANDLE hFile), -253, -253)
 
 #undef FUNCPTR
 #undef ASMPTR

--- a/BH/D2Ptrs.h
+++ b/BH/D2Ptrs.h
@@ -491,7 +491,6 @@ FUNCPTR(D2MCPCLIENT, ParseGameListPacket, VOID __fastcall, (BYTE* pPacket), 0x6E
 // Storm Functions
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
-FUNCPTR(STORM, SFileOpenFileEx, bool __stdcall, (HANDLE hMpq, const char* szFileName, DWORD dwSearchScope, HANDLE* phFile), -268, -268)
 FUNCPTR(STORM, SFileReadFile, bool __stdcall, (HANDLE hFile, VOID* lpBuffer, DWORD dwToRead, DWORD* pdwRead, LPOVERLAPPED lpOverlapped), -269, -269)
 
 #undef FUNCPTR

--- a/BH/D2Ptrs.h
+++ b/BH/D2Ptrs.h
@@ -487,12 +487,6 @@ VARPTR(D2WIN, FocusedControl, Control*, 0x214B0, 0x8DB44) // unused, but we ough
 
 FUNCPTR(D2MCPCLIENT, ParseGameListPacket, VOID __fastcall, (BYTE* pPacket), 0x6E30, 0x6640)
 
-////////////////////////////////////////////////////////////////////////////////////////////////
-// Storm Functions
-////////////////////////////////////////////////////////////////////////////////////////////////
-
-FUNCPTR(STORM, SFileReadFile, bool __stdcall, (HANDLE hFile, VOID* lpBuffer, DWORD dwToRead, DWORD* pdwRead, LPOVERLAPPED lpOverlapped), -269, -269)
-
 #undef FUNCPTR
 #undef ASMPTR
 #undef VARPTR

--- a/BH/D2Ptrs.h
+++ b/BH/D2Ptrs.h
@@ -491,7 +491,6 @@ FUNCPTR(D2MCPCLIENT, ParseGameListPacket, VOID __fastcall, (BYTE* pPacket), 0x6E
 // Storm Functions
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
-FUNCPTR(STORM, SFileOpenArchive, bool __stdcall, (const char* szMpqName, DWORD dwPriority, DWORD dwFlags, HANDLE* phMPQ), -266, -266)
 FUNCPTR(STORM, SFileCloseArchive, bool __stdcall, (HANDLE hMpq), -252, -252)
 FUNCPTR(STORM, SFileOpenFileEx, bool __stdcall, (HANDLE hMpq, const char* szFileName, DWORD dwSearchScope, HANDLE* phFile), -268, -268)
 FUNCPTR(STORM, SFileGetFileSize, bool __stdcall, (HANDLE hFile, DWORD* pdwFileSizeHigh), -265, -265)

--- a/BH/MPQReader.cpp
+++ b/BH/MPQReader.cpp
@@ -14,6 +14,7 @@
 #include "bh/d2/storm/function/file_close_archive.hpp"
 #include "bh/d2/storm/function/file_close_file.hpp"
 #include "bh/d2/storm/function/file_open_archive.hpp"
+#include "bh/d2/storm/function/file_open_file_ex.hpp"
 #include "Constants.h"
 #include "D2Ptrs.h"
 
@@ -45,7 +46,7 @@ HANDLE MPQArchive::GetHandle() {
 
 
 MPQFile::MPQFile(MPQArchive *archive, const char *filename) : name(filename), error(ERROR_SUCCESS) {
-	if (!STORM_SFileOpenFileEx(archive->GetHandle(), filename, 0, &hMpqFile)) {
+	if (!storm::SFileOpenFileEx(archive->GetHandle(), filename, 0, &hMpqFile)) {
 		error = GetLastError();
 	}
 }

--- a/BH/MPQReader.cpp
+++ b/BH/MPQReader.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 
+#include "bh/d2/storm/function/file_close_archive.hpp"
 #include "bh/d2/storm/function/file_close_file.hpp"
 #include "bh/d2/storm/function/file_open_archive.hpp"
 #include "Constants.h"
@@ -35,7 +36,7 @@ MPQArchive::MPQArchive(const char *filename) : name(filename), error(ERROR_SUCCE
 }
 MPQArchive::~MPQArchive() {
 	if (hMpq != NULL) {
-		STORM_SFileCloseArchive(hMpq);
+		storm::SFileCloseArchive(hMpq);
 	}
 }
 HANDLE MPQArchive::GetHandle() {

--- a/BH/MPQReader.cpp
+++ b/BH/MPQReader.cpp
@@ -15,6 +15,7 @@
 #include "bh/d2/storm/function/file_close_file.hpp"
 #include "bh/d2/storm/function/file_open_archive.hpp"
 #include "bh/d2/storm/function/file_open_file_ex.hpp"
+#include "bh/d2/storm/function/file_read_file.hpp"
 #include "Constants.h"
 #include "D2Ptrs.h"
 
@@ -65,7 +66,7 @@ MPQData::MPQData(MPQFile *file) : error(ERROR_SUCCESS) {
 	std::string buffer;
 	char szBuffer[0x10000];
 	while (dwBytes > 0) {
-		STORM_SFileReadFile(file->GetHandle(), szBuffer, sizeof(szBuffer), &dwBytes, NULL);
+		storm::SFileReadFile(file->GetHandle(), szBuffer, sizeof(szBuffer), &dwBytes, NULL);
 		if (dwBytes > 0) {
 			buffer.append(szBuffer, dwBytes);
 		}

--- a/BH/MPQReader.cpp
+++ b/BH/MPQReader.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 
+#include "bh/d2/storm/function/file_close_file.hpp"
 #include "bh/d2/storm/function/file_open_archive.hpp"
 #include "Constants.h"
 #include "D2Ptrs.h"
@@ -49,7 +50,7 @@ MPQFile::MPQFile(MPQArchive *archive, const char *filename) : name(filename), er
 }
 MPQFile::~MPQFile() {
 	if (hMpqFile != NULL) {
-		STORM_SFileCloseFile(hMpqFile);
+		storm::SFileCloseFile(hMpqFile);
 	}
 }
 HANDLE MPQFile::GetHandle() {

--- a/BH/MPQReader.cpp
+++ b/BH/MPQReader.cpp
@@ -11,8 +11,15 @@
 #include <string>
 #include <vector>
 
+#include "bh/d2/storm/function/file_open_archive.hpp"
 #include "Constants.h"
 #include "D2Ptrs.h"
+
+namespace {
+
+namespace storm = ::bh::d2::storm;
+
+}  // namespace
 
 std::map<std::string, MPQData*> MpqDataMap;
 std::string MpqVersion;
@@ -21,7 +28,7 @@ std::string MpqVersion;
 #define STREAM_FLAG_READ_ONLY 0x00000100  // Stream is read only
 
 MPQArchive::MPQArchive(const char *filename) : name(filename), error(ERROR_SUCCESS) {
-	if (!STORM_SFileOpenArchive(filename, 0, STREAM_FLAG_READ_ONLY, &hMpq)) {
+	if (!storm::SFileOpenArchive(filename, 0, STREAM_FLAG_READ_ONLY, &hMpq)) {
 		error = GetLastError();
 	}
 }

--- a/src/bh/d2/d2client/CMakeLists.txt
+++ b/src/bh/d2/d2client/CMakeLists.txt
@@ -16,12 +16,3 @@
 # You should have received a copy of the GNU Affero General Public
 # License along with this program.  If not, see
 # <http://www.gnu.org/licenses/>.
-
-target_sources(${PROJECT_NAME}
-    PRIVATE
-        "${CMAKE_CURRENT_SOURCE_DIR}/file_open_archive.cpp"
-        "${CMAKE_CURRENT_SOURCE_DIR}/file_open_archive.hpp"
-
-        "${CMAKE_CURRENT_SOURCE_DIR}/file_open_archive.cpp"
-        "${CMAKE_CURRENT_SOURCE_DIR}/file_open_archive.hpp"
-)

--- a/src/bh/d2/storm/CMakeLists.txt
+++ b/src/bh/d2/storm/CMakeLists.txt
@@ -17,7 +17,4 @@
 # License along with this program.  If not, see
 # <http://www.gnu.org/licenses/>.
 
-add_subdirectory("d2lang")
-add_subdirectory("dll")
-add_subdirectory("exe")
-add_subdirectory("storm")
+add_subdirectory("function")

--- a/src/bh/d2/storm/function/CMakeLists.txt
+++ b/src/bh/d2/storm/function/CMakeLists.txt
@@ -25,6 +25,9 @@ target_sources(${PROJECT_NAME}
         "${CMAKE_CURRENT_SOURCE_DIR}/file_close_file.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/file_close_file.hpp"
 
+        "${CMAKE_CURRENT_SOURCE_DIR}/file_get_file_size.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/file_get_file_size.hpp"
+
         "${CMAKE_CURRENT_SOURCE_DIR}/file_open_archive.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/file_open_archive.hpp"
 )

--- a/src/bh/d2/storm/function/CMakeLists.txt
+++ b/src/bh/d2/storm/function/CMakeLists.txt
@@ -33,6 +33,9 @@ target_sources(${PROJECT_NAME}
 
         "${CMAKE_CURRENT_SOURCE_DIR}/file_open_file_ex.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/file_open_file_ex.hpp"
+
+        "${CMAKE_CURRENT_SOURCE_DIR}/file_read_file.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/file_read_file.hpp"
 )
 
 add_subdirectory("v1_00")

--- a/src/bh/d2/storm/function/CMakeLists.txt
+++ b/src/bh/d2/storm/function/CMakeLists.txt
@@ -30,6 +30,9 @@ target_sources(${PROJECT_NAME}
 
         "${CMAKE_CURRENT_SOURCE_DIR}/file_open_archive.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/file_open_archive.hpp"
+
+        "${CMAKE_CURRENT_SOURCE_DIR}/file_open_file_ex.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/file_open_file_ex.hpp"
 )
 
 add_subdirectory("v1_00")

--- a/src/bh/d2/storm/function/CMakeLists.txt
+++ b/src/bh/d2/storm/function/CMakeLists.txt
@@ -17,7 +17,10 @@
 # License along with this program.  If not, see
 # <http://www.gnu.org/licenses/>.
 
-add_subdirectory("d2lang")
-add_subdirectory("dll")
-add_subdirectory("exe")
-add_subdirectory("storm")
+target_sources(${PROJECT_NAME}
+    PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/file_open_archive.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/file_open_archive.hpp"
+)
+
+add_subdirectory("v1_00")

--- a/src/bh/d2/storm/function/CMakeLists.txt
+++ b/src/bh/d2/storm/function/CMakeLists.txt
@@ -19,6 +19,9 @@
 
 target_sources(${PROJECT_NAME}
     PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/file_close_archive.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/file_close_archive.hpp"
+
         "${CMAKE_CURRENT_SOURCE_DIR}/file_close_file.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/file_close_file.hpp"
 

--- a/src/bh/d2/storm/function/CMakeLists.txt
+++ b/src/bh/d2/storm/function/CMakeLists.txt
@@ -19,6 +19,9 @@
 
 target_sources(${PROJECT_NAME}
     PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/file_close_file.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/file_close_file.hpp"
+
         "${CMAKE_CURRENT_SOURCE_DIR}/file_open_archive.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/file_open_archive.hpp"
 )

--- a/src/bh/d2/storm/function/file_close_archive.cpp
+++ b/src/bh/d2/storm/function/file_close_archive.cpp
@@ -1,0 +1,69 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#include "bh/d2/storm/function/file_close_archive.hpp"
+
+#include <assert.h>
+#include <windows.h>
+
+#include "bh/common/logging/logger.hpp"
+#include "bh/d2/exe/version.hpp"
+#include "bh/d2/storm/function/v1_00/file_close_archive.hpp"
+#include "bh/global/file_logger.hpp"
+
+namespace bh::d2::storm {
+
+using ::bh::common::logging::Logger;
+using ::bh::d2::exe::version::GetRunning;
+using ::bh::d2::exe::version::Version;
+using ::bh::global::GetFileLogger;
+
+static Logger& GetLogger() {
+  static Logger& logger = GetFileLogger(__FILEW__);
+  return logger;
+}
+
+BOOL SFileCloseArchive(HANDLE mpq) {
+  Version version = GetRunning();
+  switch (version) {
+    case Version::k1_13c:
+    case Version::k1_13d:
+    case Version::k1_14d: {
+      return v1_00::SFileCloseArchive(mpq);
+    }
+  }
+
+  // This should never happen.
+  GetLogger().Fatal(
+      __LINE__,
+      "Unhandled Version with value {:d}",
+      static_cast<int>(version));
+  return FALSE;
+}
+
+}  // namespace bh::d2::storm

--- a/src/bh/d2/storm/function/file_close_archive.hpp
+++ b/src/bh/d2/storm/function/file_close_archive.hpp
@@ -1,0 +1,40 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#ifndef BH_D2_STORM_FUNCTION_FILE_CLOSE_ARCHIVE_HPP_
+#define BH_D2_STORM_FUNCTION_FILE_CLOSE_ARCHIVE_HPP_
+
+#include <windows.h>
+
+namespace bh::d2::storm {
+
+BOOL SFileCloseArchive(HANDLE mpq);
+
+}  // namespace bh::d2::storm
+
+#endif  // BH_D2_STORM_FUNCTION_FILE_CLOSE_ARCHIVE_HPP_

--- a/src/bh/d2/storm/function/file_close_file.cpp
+++ b/src/bh/d2/storm/function/file_close_file.cpp
@@ -1,0 +1,69 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#include "bh/d2/storm/function/file_open_archive.hpp"
+
+#include <assert.h>
+#include <windows.h>
+
+#include "bh/common/logging/logger.hpp"
+#include "bh/d2/exe/version.hpp"
+#include "bh/d2/storm/function/v1_00/file_close_file.hpp"
+#include "bh/global/file_logger.hpp"
+
+namespace bh::d2::storm {
+
+using ::bh::common::logging::Logger;
+using ::bh::d2::exe::version::GetRunning;
+using ::bh::d2::exe::version::Version;
+using ::bh::global::GetFileLogger;
+
+static Logger& GetLogger() {
+  static Logger& logger = GetFileLogger(__FILEW__);
+  return logger;
+}
+
+BOOL SFileCloseFile(HANDLE file) {
+  Version version = GetRunning();
+  switch (version) {
+    case Version::k1_13c:
+    case Version::k1_13d:
+    case Version::k1_14d: {
+      return v1_00::SFileCloseFile(file);
+    }
+  }
+
+  // This should never happen.
+  GetLogger().Fatal(
+      __LINE__,
+      "Unhandled Version with value {:d}",
+      static_cast<int>(version));
+  return FALSE;
+}
+
+}  // namespace bh::d2::storm

--- a/src/bh/d2/storm/function/file_close_file.hpp
+++ b/src/bh/d2/storm/function/file_close_file.hpp
@@ -1,0 +1,41 @@
+
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#ifndef BH_D2_STORM_FUNCTION_FILE_CLOSE_FILE_HPP_
+#define BH_D2_STORM_FUNCTION_FILE_CLOSE_FILE_HPP_
+
+#include <windows.h>
+
+namespace bh::d2::storm {
+
+BOOL SFileCloseFile(HANDLE file);
+
+}  // namespace bh::d2::storm
+
+#endif  // BH_D2_STORM_FUNCTION_FILE_CLOSE_FILE_HPP_

--- a/src/bh/d2/storm/function/file_get_file_size.cpp
+++ b/src/bh/d2/storm/function/file_get_file_size.cpp
@@ -1,0 +1,71 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#include "bh/d2/storm/function/file_get_file_size.hpp"
+
+#include <assert.h>
+#include <windows.h>
+
+#include "bh/common/logging/logger.hpp"
+#include "bh/d2/exe/version.hpp"
+#include "bh/d2/storm/function/v1_00/file_get_file_size.hpp"
+#include "bh/global/file_logger.hpp"
+
+namespace bh::d2::storm {
+
+using ::bh::common::logging::Logger;
+using ::bh::d2::exe::version::GetRunning;
+using ::bh::d2::exe::version::Version;
+using ::bh::global::GetFileLogger;
+
+static Logger& GetLogger() {
+  static Logger& logger = GetFileLogger(__FILEW__);
+  return logger;
+}
+
+BOOL SFileGetFileSize(HANDLE file, DWORD* file_size_high) {
+  Version version = GetRunning();
+  switch (version) {
+    case Version::k1_13c:
+    case Version::k1_13d:
+    case Version::k1_14d: {
+      uint32_t* file_size_high_v1_00 =
+          reinterpret_cast<uint32_t*>(file_size_high);
+      return v1_00::SFileGetFileSize(file, file_size_high_v1_00);
+    }
+  }
+
+  // This should never happen.
+  GetLogger().Fatal(
+      __LINE__,
+      "Unhandled Version with value {:d}",
+      static_cast<int>(version));
+  return FALSE;
+}
+
+}  // namespace bh::d2::storm

--- a/src/bh/d2/storm/function/file_get_file_size.hpp
+++ b/src/bh/d2/storm/function/file_get_file_size.hpp
@@ -1,0 +1,41 @@
+
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#ifndef BH_D2_STORM_FUNCTION_FILE_GET_FILE_SIZE_HPP_
+#define BH_D2_STORM_FUNCTION_FILE_GET_FILE_SIZE_HPP_
+
+#include <windows.h>
+
+namespace bh::d2::storm {
+
+BOOL SFileGetFileSize(HANDLE file, DWORD* file_size_high);
+
+}  // namespace bh::d2::storm
+
+#endif  // BH_D2_STORM_FUNCTION_FILE_GET_FILE_SIZE_HPP_

--- a/src/bh/d2/storm/function/file_open_archive.cpp
+++ b/src/bh/d2/storm/function/file_open_archive.cpp
@@ -1,0 +1,57 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#include "bh/d2/storm/function/file_open_archive.hpp"
+
+#include <assert.h>
+#include <windows.h>
+
+#include "bh/d2/storm/function/v1_00/file_open_archive.hpp"
+#include "bh/d2/exe/version.hpp"
+
+namespace bh::d2::storm {
+
+using ::bh::d2::exe::version::GetRunning;
+using ::bh::d2::exe::version::Version;
+
+BOOL SFileOpenArchive(
+    const char* path, DWORD priority, DWORD flags, HANDLE* mpq) {
+  switch (GetRunning()) {
+    case Version::k1_13c:
+    case Version::k1_13d:
+    case Version::k1_14d: {
+      return v1_00::SFileOpenArchive(path, priority, flags, mpq);
+    }
+  }
+
+  // This should never happen.
+  assert(false);
+  return FALSE;
+}
+
+}  // namespace bh::d2::storm

--- a/src/bh/d2/storm/function/file_open_archive.cpp
+++ b/src/bh/d2/storm/function/file_open_archive.cpp
@@ -31,17 +31,27 @@
 #include <assert.h>
 #include <windows.h>
 
-#include "bh/d2/storm/function/v1_00/file_open_archive.hpp"
+#include "bh/common/logging/logger.hpp"
 #include "bh/d2/exe/version.hpp"
+#include "bh/d2/storm/function/v1_00/file_open_archive.hpp"
+#include "bh/global/file_logger.hpp"
 
 namespace bh::d2::storm {
 
+using ::bh::common::logging::Logger;
 using ::bh::d2::exe::version::GetRunning;
 using ::bh::d2::exe::version::Version;
+using ::bh::global::GetFileLogger;
+
+static Logger& GetLogger() {
+  static Logger& logger = GetFileLogger(__FILEW__);
+  return logger;
+}
 
 BOOL SFileOpenArchive(
     const char* path, DWORD priority, DWORD flags, HANDLE* mpq) {
-  switch (GetRunning()) {
+  Version version = GetRunning();
+  switch (version) {
     case Version::k1_13c:
     case Version::k1_13d:
     case Version::k1_14d: {
@@ -50,7 +60,10 @@ BOOL SFileOpenArchive(
   }
 
   // This should never happen.
-  assert(false);
+  GetLogger().Fatal(
+      __LINE__,
+      "Unhandled Version with value {:d}",
+      static_cast<int>(version));
   return FALSE;
 }
 

--- a/src/bh/d2/storm/function/file_open_archive.hpp
+++ b/src/bh/d2/storm/function/file_open_archive.hpp
@@ -1,0 +1,41 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#ifndef BH_D2_STORM_FUNCTION_FILE_OPEN_ARCHIVE_HPP_
+#define BH_D2_STORM_FUNCTION_FILE_OPEN_ARCHIVE_HPP_
+
+#include <windows.h>
+
+namespace bh::d2::storm {
+
+BOOL SFileOpenArchive(
+    const char* path, DWORD priority, DWORD flags, HANDLE* mpq);
+
+}  // namespace bh::d2::storm
+
+#endif  // BH_D2_STORM_FUNCTION_FILE_OPEN_ARCHIVE_HPP_

--- a/src/bh/d2/storm/function/file_open_file_ex.cpp
+++ b/src/bh/d2/storm/function/file_open_file_ex.cpp
@@ -1,0 +1,70 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#include "bh/d2/storm/function/file_open_file_ex.hpp"
+
+#include <assert.h>
+#include <windows.h>
+
+#include "bh/common/logging/logger.hpp"
+#include "bh/d2/exe/version.hpp"
+#include "bh/d2/storm/function/v1_00/file_open_file_ex.hpp"
+#include "bh/global/file_logger.hpp"
+
+namespace bh::d2::storm {
+
+using ::bh::common::logging::Logger;
+using ::bh::d2::exe::version::GetRunning;
+using ::bh::d2::exe::version::Version;
+using ::bh::global::GetFileLogger;
+
+static Logger& GetLogger() {
+  static Logger& logger = GetFileLogger(__FILEW__);
+  return logger;
+}
+
+BOOL SFileOpenFileEx(
+    HANDLE mpq, const char* path, DWORD search_scope, HANDLE* file) {
+  Version version = GetRunning();
+  switch (version) {
+    case Version::k1_13c:
+    case Version::k1_13d:
+    case Version::k1_14d: {
+      return v1_00::SFileOpenFileEx(mpq, path, search_scope, file);
+    }
+  }
+
+  // This should never happen.
+  GetLogger().Fatal(
+      __LINE__,
+      "Unhandled Version with value {:d}",
+      static_cast<int>(version));
+  return FALSE;
+}
+
+}  // namespace bh::d2::storm

--- a/src/bh/d2/storm/function/file_open_file_ex.hpp
+++ b/src/bh/d2/storm/function/file_open_file_ex.hpp
@@ -1,0 +1,41 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#ifndef BH_D2_STORM_FUNCTION_FILE_OPEN_FILE_EX_HPP_
+#define BH_D2_STORM_FUNCTION_FILE_OPEN_FILE_EX_HPP_
+
+#include <windows.h>
+
+namespace bh::d2::storm {
+
+BOOL SFileOpenFileEx(
+    HANDLE mpq, const char* path, DWORD search_scope, HANDLE* file);
+
+}  // namespace bh::d2::storm
+
+#endif  // BH_D2_STORM_FUNCTION_FILE_OPEN_FILE_EX_HPP_

--- a/src/bh/d2/storm/function/file_read_file.cpp
+++ b/src/bh/d2/storm/function/file_read_file.cpp
@@ -1,0 +1,76 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#include "bh/d2/storm/function/file_read_file.hpp"
+
+#include <assert.h>
+#include <windows.h>
+
+#include "bh/common/logging/logger.hpp"
+#include "bh/d2/exe/version.hpp"
+#include "bh/d2/storm/function/v1_00/file_read_file.hpp"
+#include "bh/global/file_logger.hpp"
+
+namespace bh::d2::storm {
+
+using ::bh::common::logging::Logger;
+using ::bh::d2::exe::version::GetRunning;
+using ::bh::d2::exe::version::Version;
+using ::bh::global::GetFileLogger;
+
+static Logger& GetLogger() {
+  static Logger& logger = GetFileLogger(__FILEW__);
+  return logger;
+}
+
+BOOL SFileReadFile(
+    HANDLE file,
+    void* buffer,
+    DWORD buffer_size,
+    DWORD* read_count,
+    OVERLAPPED* overlapped) {
+  Version version = GetRunning();
+  switch (version) {
+    case Version::k1_13c:
+    case Version::k1_13d:
+    case Version::k1_14d: {
+      uint32_t* read_count_v1_00 = reinterpret_cast<uint32_t*>(read_count);
+      return v1_00::SFileReadFile(
+          file, buffer, buffer_size, read_count_v1_00, overlapped);
+    }
+  }
+
+  // This should never happen.
+  GetLogger().Fatal(
+      __LINE__,
+      "Unhandled Version with value {:d}",
+      static_cast<int>(version));
+  return FALSE;
+}
+
+}  // namespace bh::d2::storm

--- a/src/bh/d2/storm/function/file_read_file.hpp
+++ b/src/bh/d2/storm/function/file_read_file.hpp
@@ -1,0 +1,45 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#ifndef BH_D2_STORM_FUNCTION_FILE_READ_FILE_HPP_
+#define BH_D2_STORM_FUNCTION_FILE_READ_FILE_HPP_
+
+#include <windows.h>
+
+namespace bh::d2::storm {
+
+BOOL SFileReadFile(
+    HANDLE file,
+    void* buffer,
+    DWORD buffer_size,
+    DWORD* read_count,
+    OVERLAPPED* overlapped);
+
+}  // namespace bh::d2::storm
+
+#endif  // BH_D2_STORM_FUNCTION_FILE_READ_FILE_HPP_

--- a/src/bh/d2/storm/function/v1_00/CMakeLists.txt
+++ b/src/bh/d2/storm/function/v1_00/CMakeLists.txt
@@ -17,7 +17,8 @@
 # License along with this program.  If not, see
 # <http://www.gnu.org/licenses/>.
 
-add_subdirectory("d2lang")
-add_subdirectory("dll")
-add_subdirectory("exe")
-add_subdirectory("storm")
+target_sources(${PROJECT_NAME}
+    PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/file_open_archive.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/file_open_archive.hpp"
+)

--- a/src/bh/d2/storm/function/v1_00/CMakeLists.txt
+++ b/src/bh/d2/storm/function/v1_00/CMakeLists.txt
@@ -25,6 +25,9 @@ target_sources(${PROJECT_NAME}
         "${CMAKE_CURRENT_SOURCE_DIR}/file_close_file.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/file_close_file.hpp"
 
+        "${CMAKE_CURRENT_SOURCE_DIR}/file_get_file_size.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/file_get_file_size.hpp"
+
         "${CMAKE_CURRENT_SOURCE_DIR}/file_open_archive.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/file_open_archive.hpp"
 )

--- a/src/bh/d2/storm/function/v1_00/CMakeLists.txt
+++ b/src/bh/d2/storm/function/v1_00/CMakeLists.txt
@@ -30,4 +30,7 @@ target_sources(${PROJECT_NAME}
 
         "${CMAKE_CURRENT_SOURCE_DIR}/file_open_archive.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/file_open_archive.hpp"
+
+        "${CMAKE_CURRENT_SOURCE_DIR}/file_open_file_ex.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/file_open_file_ex.hpp"
 )

--- a/src/bh/d2/storm/function/v1_00/CMakeLists.txt
+++ b/src/bh/d2/storm/function/v1_00/CMakeLists.txt
@@ -19,6 +19,9 @@
 
 target_sources(${PROJECT_NAME}
     PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/file_close_archive.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/file_close_archive.hpp"
+
         "${CMAKE_CURRENT_SOURCE_DIR}/file_close_file.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/file_close_file.hpp"
 

--- a/src/bh/d2/storm/function/v1_00/CMakeLists.txt
+++ b/src/bh/d2/storm/function/v1_00/CMakeLists.txt
@@ -33,4 +33,7 @@ target_sources(${PROJECT_NAME}
 
         "${CMAKE_CURRENT_SOURCE_DIR}/file_open_file_ex.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/file_open_file_ex.hpp"
+
+        "${CMAKE_CURRENT_SOURCE_DIR}/file_read_file.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/file_read_file.hpp"
 )

--- a/src/bh/d2/storm/function/v1_00/CMakeLists.txt
+++ b/src/bh/d2/storm/function/v1_00/CMakeLists.txt
@@ -19,8 +19,8 @@
 
 target_sources(${PROJECT_NAME}
     PRIVATE
-        "${CMAKE_CURRENT_SOURCE_DIR}/file_open_archive.cpp"
-        "${CMAKE_CURRENT_SOURCE_DIR}/file_open_archive.hpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/file_close_file.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/file_close_file.hpp"
 
         "${CMAKE_CURRENT_SOURCE_DIR}/file_open_archive.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/file_open_archive.hpp"

--- a/src/bh/d2/storm/function/v1_00/file_close_archive.cpp
+++ b/src/bh/d2/storm/function/v1_00/file_close_archive.cpp
@@ -60,10 +60,7 @@ static Logger& GetLogger() {
 
 static std::variant<Offset, Ordinal> GetOffsetOrOrdinal(Version version) {
   switch (version) {
-    case Version::k1_13c: {
-      return Ordinal(252);
-    }
-
+    case Version::k1_13c:
     case Version::k1_13d: {
       return Ordinal(252);
     }

--- a/src/bh/d2/storm/function/v1_00/file_close_archive.cpp
+++ b/src/bh/d2/storm/function/v1_00/file_close_archive.cpp
@@ -1,0 +1,100 @@
+
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#include "bh/d2/storm/function/v1_00/file_close_archive.hpp"
+
+#include <assert.h>
+#include <stdint.h>
+#include <windows.h>
+
+#include <variant>
+
+#include "bh/common/logging/logger.hpp"
+#include "bh/d2/dll/address.hpp"
+#include "bh/d2/dll/dll.hpp"
+#include "bh/d2/exe/version.hpp"
+#include "bh/global/file_logger.hpp"
+
+namespace bh::d2::storm::v1_00 {
+namespace {
+
+using ::bh::common::logging::Logger;
+using ::bh::d2::dll::Dll;
+using ::bh::d2::dll::GetAddress;
+using ::bh::d2::dll::Offset;
+using ::bh::d2::dll::Ordinal;
+using ::bh::d2::exe::version::GetRunning;
+using ::bh::d2::exe::version::Version;
+using ::bh::global::GetFileLogger;
+
+static Logger& GetLogger() {
+  static Logger& logger = GetFileLogger(__FILEW__);
+  return logger;
+}
+
+static std::variant<Offset, Ordinal> GetOffsetOrOrdinal(Version version) {
+  switch (version) {
+    case Version::k1_13c: {
+      return Ordinal(252);
+    }
+
+    case Version::k1_13d: {
+      return Ordinal(252);
+    }
+
+    case Version::k1_14d: {
+      return Offset(0x19A80);
+    }
+  }
+
+  // This should never happen.
+  GetLogger().Fatal(
+      __LINE__,
+      "Unhandled Version with value {:d}",
+      static_cast<int>(version));
+  return Offset(0);
+}
+
+}  // namespace
+
+uint32_t SFileCloseArchive(HANDLE mpq) {
+  using FuncType = uint32_t (__stdcall)(HANDLE);
+
+  static FuncType* func =
+      std::visit(
+          [] (auto value) {
+            void* address = GetAddress(Dll::kStorm, value);
+            return reinterpret_cast<FuncType*>(address);
+          },
+          GetOffsetOrOrdinal(GetRunning()));
+
+  return func(mpq);
+}
+
+}  // namespace bh::d2::storm::v1_00

--- a/src/bh/d2/storm/function/v1_00/file_close_archive.hpp
+++ b/src/bh/d2/storm/function/v1_00/file_close_archive.hpp
@@ -1,0 +1,42 @@
+
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#ifndef BH_D2_STORM_FUNCTION_V1_00_FILE_CLOSE_ARCHIVE_HPP_
+#define BH_D2_STORM_FUNCTION_V1_00_FILE_CLOSE_ARCHIVE_HPP_
+
+#include <stdint.h>
+#include <windows.h>
+
+namespace bh::d2::storm::v1_00 {
+
+uint32_t SFileCloseArchive(HANDLE mpq);
+
+}  // namespace bh::d2::storm::v1_00
+
+#endif  // BH_D2_STORM_FUNCTION_V1_00_FILE_CLOSE_ARCHIVE_HPP_

--- a/src/bh/d2/storm/function/v1_00/file_close_file.cpp
+++ b/src/bh/d2/storm/function/v1_00/file_close_file.cpp
@@ -60,10 +60,7 @@ static Logger& GetLogger() {
 
 static std::variant<Offset, Ordinal> GetOffsetOrOrdinal(Version version) {
   switch (version) {
-    case Version::k1_13c: {
-      return Ordinal(253);
-    }
-
+    case Version::k1_13c:
     case Version::k1_13d: {
       return Ordinal(253);
     }

--- a/src/bh/d2/storm/function/v1_00/file_close_file.cpp
+++ b/src/bh/d2/storm/function/v1_00/file_close_file.cpp
@@ -1,0 +1,96 @@
+
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#include "bh/d2/storm/function/v1_00/file_open_archive.hpp"
+
+#include <assert.h>
+#include <stdint.h>
+#include <windows.h>
+
+#include <variant>
+
+#include "bh/common/logging/logger.hpp"
+#include "bh/d2/dll/address.hpp"
+#include "bh/d2/dll/dll.hpp"
+#include "bh/d2/exe/version.hpp"
+#include "bh/global/file_logger.hpp"
+
+namespace bh::d2::storm::v1_00 {
+namespace {
+
+using ::bh::common::logging::Logger;
+using ::bh::d2::dll::Dll;
+using ::bh::d2::dll::GetAddress;
+using ::bh::d2::dll::Offset;
+using ::bh::d2::dll::Ordinal;
+using ::bh::d2::exe::version::GetRunning;
+using ::bh::d2::exe::version::Version;
+using ::bh::d2::global::GetFileLogger;
+
+static Logger& GetLogger() {
+  static Logger& logger = GetFileLogger(logger);
+  return logger;
+}
+
+static std::variant<Offset, Ordinal> GetOffsetOrOrdinal(Version version) {
+  switch (version) {
+    case Version::k1_13c: {
+      return Ordinal(253);
+    }
+
+    case Version::k1_13d: {
+      return Ordinal(253);
+    }
+  }
+
+  // This should never happen.
+  GetLogger().Fatal(
+      __LINE__,
+      "Unhandled Version with value {:d}",
+      static_cast<int>(version));
+  return Offset(0);
+}
+
+}  // namespace
+
+uint32_t SFileCloseFile(HANDLE file) {
+  using FuncType = uint32_t (__stdcall)(HANDLE);
+
+  static FuncType* func =
+      std::visit(
+          [] (auto value) {
+            void* address = GetAddress(Dll::kStorm, value);
+            return reinterpret_cast<FuncType*>(address);
+          },
+          GetOffsetOrOrdinal(GetRunning()));
+
+  return func(file);
+}
+
+}  // namespace bh::d2::storm::v1_00

--- a/src/bh/d2/storm/function/v1_00/file_close_file.cpp
+++ b/src/bh/d2/storm/function/v1_00/file_close_file.cpp
@@ -51,10 +51,10 @@ using ::bh::d2::dll::Offset;
 using ::bh::d2::dll::Ordinal;
 using ::bh::d2::exe::version::GetRunning;
 using ::bh::d2::exe::version::Version;
-using ::bh::d2::global::GetFileLogger;
+using ::bh::global::GetFileLogger;
 
 static Logger& GetLogger() {
-  static Logger& logger = GetFileLogger(logger);
+  static Logger& logger = GetFileLogger(__FILEW__);
   return logger;
 }
 

--- a/src/bh/d2/storm/function/v1_00/file_close_file.hpp
+++ b/src/bh/d2/storm/function/v1_00/file_close_file.hpp
@@ -1,0 +1,42 @@
+
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#ifndef BH_D2_STORM_FUNCTION_V1_00_FILE_CLOSE_FILE_HPP_
+#define BH_D2_STORM_FUNCTION_V1_00_FILE_CLOSE_FILE_HPP_
+
+#include <stdint.h>
+#include <windows.h>
+
+namespace bh::d2::storm::v1_00 {
+
+uint32_t SFileCloseFile(HANDLE file);
+
+}  // namespace bh::d2::storm::v1_00
+
+#endif  // BH_D2_STORM_FUNCTION_V1_00_FILE_CLOSE_FILE_HPP_

--- a/src/bh/d2/storm/function/v1_00/file_get_file_size.cpp
+++ b/src/bh/d2/storm/function/v1_00/file_get_file_size.cpp
@@ -1,0 +1,93 @@
+
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#include "bh/d2/storm/function/v1_00/file_get_file_size.hpp"
+
+#include <assert.h>
+#include <stdint.h>
+#include <windows.h>
+
+#include <variant>
+
+#include "bh/common/logging/logger.hpp"
+#include "bh/d2/dll/address.hpp"
+#include "bh/d2/dll/dll.hpp"
+#include "bh/d2/exe/version.hpp"
+#include "bh/global/file_logger.hpp"
+
+namespace bh::d2::storm::v1_00 {
+namespace {
+
+using ::bh::common::logging::Logger;
+using ::bh::d2::dll::Dll;
+using ::bh::d2::dll::GetAddress;
+using ::bh::d2::dll::Offset;
+using ::bh::d2::dll::Ordinal;
+using ::bh::d2::exe::version::GetRunning;
+using ::bh::d2::exe::version::Version;
+using ::bh::global::GetFileLogger;
+
+static Logger& GetLogger() {
+  static Logger& logger = GetFileLogger(__FILEW__);
+  return logger;
+}
+
+static std::variant<Offset, Ordinal> GetOffsetOrOrdinal(Version version) {
+  switch (version) {
+    case Version::k1_13c:
+    case Version::k1_13d: {
+      return Ordinal(265);
+    }
+  }
+
+  // This should never happen.
+  GetLogger().Fatal(
+      __LINE__,
+      "Unhandled Version with value {:d}",
+      static_cast<int>(version));
+  return Offset(0);
+}
+
+}  // namespace
+
+uint32_t SFileGetFileSize(HANDLE file, uint32_t* file_size_high) {
+  using FuncType = uint32_t (__stdcall)(HANDLE, uint32_t*);
+
+  static FuncType* func =
+      std::visit(
+          [] (auto value) {
+            void* address = GetAddress(Dll::kStorm, value);
+            return reinterpret_cast<FuncType*>(address);
+          },
+          GetOffsetOrOrdinal(GetRunning()));
+
+  return func(file, file_size_high);
+}
+
+}  // namespace bh::d2::storm::v1_00

--- a/src/bh/d2/storm/function/v1_00/file_get_file_size.hpp
+++ b/src/bh/d2/storm/function/v1_00/file_get_file_size.hpp
@@ -1,0 +1,42 @@
+
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#ifndef BH_D2_STORM_FUNCTION_V1_00_FILE_GET_FILE_SIZE_HPP_
+#define BH_D2_STORM_FUNCTION_V1_00_FILE_GET_FILE_SIZE_HPP_
+
+#include <stdint.h>
+#include <windows.h>
+
+namespace bh::d2::storm::v1_00 {
+
+uint32_t SFileGetFileSize(HANDLE file, uint32_t* file_size_high);
+
+}  // namespace bh::d2::storm::v1_00
+
+#endif  // BH_D2_STORM_FUNCTION_V1_00_FILE_GET_FILE_SIZE_HPP_

--- a/src/bh/d2/storm/function/v1_00/file_open_archive.cpp
+++ b/src/bh/d2/storm/function/v1_00/file_open_archive.cpp
@@ -1,0 +1,89 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#include "bh/d2/storm/function/v1_00/file_open_archive.hpp"
+
+#include <assert.h>
+#include <stdint.h>
+#include <windows.h>
+
+#include <variant>
+
+#include "bh/d2/dll/address.hpp"
+#include "bh/d2/dll/dll.hpp"
+#include "bh/d2/exe/version.hpp"
+
+namespace bh::d2::storm::v1_00 {
+namespace {
+
+using ::bh::d2::dll::Dll;
+using ::bh::d2::dll::GetAddress;
+using ::bh::d2::dll::Offset;
+using ::bh::d2::dll::Ordinal;
+using ::bh::d2::exe::version::GetRunning;
+using ::bh::d2::exe::version::Version;
+
+static std::variant<Offset, Ordinal> GetOffsetOrOrdinal(Version version) {
+  switch (version) {
+    case Version::k1_13c: {
+      return Ordinal(266);
+    }
+
+    case Version::k1_13d: {
+      return Ordinal(266);
+    }
+
+    case Version::k1_14d: {
+      return Offset(0x1BA60);
+    }
+  }
+
+  // This should never happen.
+  assert(false);
+  return Offset(0);
+}
+
+}  // namespace
+
+uint32_t SFileOpenArchive(
+    const char* path, uint32_t priority, uint32_t flags, HANDLE* mpq) {
+  using FuncType =
+      uint32_t (__stdcall)(const char*, uint32_t, uint32_t, HANDLE*);
+
+  static FuncType* func =
+      std::visit(
+          [] (auto value) {
+            void* address = GetAddress(Dll::kStorm, value);
+            return reinterpret_cast<FuncType*>(address);
+          },
+          GetOffsetOrOrdinal(GetRunning()));
+
+  return func(path, priority, flags, mpq);
+}
+
+}  // namespace bh::d2::storm::v1_00

--- a/src/bh/d2/storm/function/v1_00/file_open_archive.cpp
+++ b/src/bh/d2/storm/function/v1_00/file_open_archive.cpp
@@ -34,19 +34,28 @@
 
 #include <variant>
 
+#include "bh/common/logging/logger.hpp"
 #include "bh/d2/dll/address.hpp"
 #include "bh/d2/dll/dll.hpp"
 #include "bh/d2/exe/version.hpp"
+#include "bh/global/file_logger.hpp"
 
 namespace bh::d2::storm::v1_00 {
 namespace {
 
+using ::bh::common::logging::Logger;
 using ::bh::d2::dll::Dll;
 using ::bh::d2::dll::GetAddress;
 using ::bh::d2::dll::Offset;
 using ::bh::d2::dll::Ordinal;
 using ::bh::d2::exe::version::GetRunning;
 using ::bh::d2::exe::version::Version;
+using ::bh::global::GetFileLogger;
+
+static Logger& GetLogger() {
+  static Logger& logger = GetFileLogger(__FILEW__);
+  return logger;
+}
 
 static std::variant<Offset, Ordinal> GetOffsetOrOrdinal(Version version) {
   switch (version) {
@@ -64,7 +73,10 @@ static std::variant<Offset, Ordinal> GetOffsetOrOrdinal(Version version) {
   }
 
   // This should never happen.
-  assert(false);
+  GetLogger().Fatal(
+      __LINE__,
+      "Unhandled Version with value {:d}",
+      static_cast<int>(version));
   return Offset(0);
 }
 

--- a/src/bh/d2/storm/function/v1_00/file_open_archive.cpp
+++ b/src/bh/d2/storm/function/v1_00/file_open_archive.cpp
@@ -59,10 +59,7 @@ static Logger& GetLogger() {
 
 static std::variant<Offset, Ordinal> GetOffsetOrOrdinal(Version version) {
   switch (version) {
-    case Version::k1_13c: {
-      return Ordinal(266);
-    }
-
+    case Version::k1_13c:
     case Version::k1_13d: {
       return Ordinal(266);
     }

--- a/src/bh/d2/storm/function/v1_00/file_open_archive.hpp
+++ b/src/bh/d2/storm/function/v1_00/file_open_archive.hpp
@@ -1,0 +1,42 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#ifndef BH_D2_STORM_FUNCTION_V1_00_FILE_OPEN_ARCHIVE_HPP_
+#define BH_D2_STORM_FUNCTION_V1_00_FILE_OPEN_ARCHIVE_HPP_
+
+#include <stdint.h>
+#include <windows.h>
+
+namespace bh::d2::storm::v1_00 {
+
+uint32_t SFileOpenArchive(
+    const char* path, uint32_t priority, uint32_t flags, HANDLE* mpq);
+
+}  // namespace bh::d2::storm::v1_00
+
+#endif  // BH_D2_STORM_FUNCTION_V1_00_FILE_OPEN_ARCHIVE_HPP_

--- a/src/bh/d2/storm/function/v1_00/file_open_file_ex.cpp
+++ b/src/bh/d2/storm/function/v1_00/file_open_file_ex.cpp
@@ -1,0 +1,94 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#include "bh/d2/storm/function/v1_00/file_open_file_ex.hpp"
+
+#include <assert.h>
+#include <stdint.h>
+#include <windows.h>
+
+#include <variant>
+
+#include "bh/common/logging/logger.hpp"
+#include "bh/d2/dll/address.hpp"
+#include "bh/d2/dll/dll.hpp"
+#include "bh/d2/exe/version.hpp"
+#include "bh/global/file_logger.hpp"
+
+namespace bh::d2::storm::v1_00 {
+namespace {
+
+using ::bh::common::logging::Logger;
+using ::bh::d2::dll::Dll;
+using ::bh::d2::dll::GetAddress;
+using ::bh::d2::dll::Offset;
+using ::bh::d2::dll::Ordinal;
+using ::bh::d2::exe::version::GetRunning;
+using ::bh::d2::exe::version::Version;
+using ::bh::global::GetFileLogger;
+
+static Logger& GetLogger() {
+  static Logger& logger = GetFileLogger(__FILEW__);
+  return logger;
+}
+
+static std::variant<Offset, Ordinal> GetOffsetOrOrdinal(Version version) {
+  switch (version) {
+    case Version::k1_13c:
+    case Version::k1_13d: {
+      return Ordinal(268);
+    }
+  }
+
+  // This should never happen.
+  GetLogger().Fatal(
+      __LINE__,
+      "Unhandled Version with value {:d}",
+      static_cast<int>(version));
+  return Offset(0);
+}
+
+}  // namespace
+
+uint32_t SFileOpenFileEx(
+    HANDLE mpq, const char* path, uint32_t search_scope, HANDLE* file) {
+  using FuncType =
+      uint32_t (__stdcall)(HANDLE, const char*, uint32_t, HANDLE*);
+
+  static FuncType* func =
+      std::visit(
+          [] (auto value) {
+            void* address = GetAddress(Dll::kStorm, value);
+            return reinterpret_cast<FuncType*>(address);
+          },
+          GetOffsetOrOrdinal(GetRunning()));
+
+  return func(mpq, path, search_scope, file);
+}
+
+}  // namespace bh::d2::storm::v1_00

--- a/src/bh/d2/storm/function/v1_00/file_open_file_ex.hpp
+++ b/src/bh/d2/storm/function/v1_00/file_open_file_ex.hpp
@@ -1,0 +1,42 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#ifndef BH_D2_STORM_FUNCTION_V1_00_FILE_OPEN_FILE_EX_HPP_
+#define BH_D2_STORM_FUNCTION_V1_00_FILE_OPEN_FILE_EX_HPP_
+
+#include <stdint.h>
+#include <windows.h>
+
+namespace bh::d2::storm::v1_00 {
+
+uint32_t SFileOpenFileEx(
+    HANDLE mpq, const char* path, uint32_t search_scope, HANDLE* file);
+
+}  // namespace bh::d2::storm::v1_00
+
+#endif  // BH_D2_STORM_FUNCTION_V1_00_FILE_OPEN_FILE_EX_HPP_

--- a/src/bh/d2/storm/function/v1_00/file_read_file.cpp
+++ b/src/bh/d2/storm/function/v1_00/file_read_file.cpp
@@ -1,0 +1,98 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#include "bh/d2/storm/function/v1_00/file_read_file.hpp"
+
+#include <assert.h>
+#include <stdint.h>
+#include <windows.h>
+
+#include <variant>
+
+#include "bh/common/logging/logger.hpp"
+#include "bh/d2/dll/address.hpp"
+#include "bh/d2/dll/dll.hpp"
+#include "bh/d2/exe/version.hpp"
+#include "bh/global/file_logger.hpp"
+
+namespace bh::d2::storm::v1_00 {
+namespace {
+
+using ::bh::common::logging::Logger;
+using ::bh::d2::dll::Dll;
+using ::bh::d2::dll::GetAddress;
+using ::bh::d2::dll::Offset;
+using ::bh::d2::dll::Ordinal;
+using ::bh::d2::exe::version::GetRunning;
+using ::bh::d2::exe::version::Version;
+using ::bh::global::GetFileLogger;
+
+static Logger& GetLogger() {
+  static Logger& logger = GetFileLogger(__FILEW__);
+  return logger;
+}
+
+static std::variant<Offset, Ordinal> GetOffsetOrOrdinal(Version version) {
+  switch (version) {
+    case Version::k1_13c:
+    case Version::k1_13d: {
+      return Ordinal(269);
+    }
+  }
+
+  // This should never happen.
+  GetLogger().Fatal(
+      __LINE__,
+      "Unhandled Version with value {:d}",
+      static_cast<int>(version));
+  return Offset(0);
+}
+
+}  // namespace
+
+uint32_t SFileReadFile(
+    HANDLE file,
+    void* buffer,
+    uint32_t buffer_size,
+    uint32_t* read_count,
+    OVERLAPPED* overlapped) {
+  using FuncType =
+      uint32_t (__stdcall)(HANDLE, void*, uint32_t, uint32_t*, OVERLAPPED*);
+
+  static FuncType* func =
+      std::visit(
+          [] (auto value) {
+            void* address = GetAddress(Dll::kStorm, value);
+            return reinterpret_cast<FuncType*>(address);
+          },
+          GetOffsetOrOrdinal(GetRunning()));
+
+  return func(file, buffer, buffer_size, read_count, overlapped);
+}
+
+}  // namespace bh::d2::storm::v1_00

--- a/src/bh/d2/storm/function/v1_00/file_read_file.hpp
+++ b/src/bh/d2/storm/function/v1_00/file_read_file.hpp
@@ -1,0 +1,47 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2022  SlashDiablo Community
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#ifndef BH_D2_STORM_FUNCTION_V1_00_FILE_READ_FILE_HPP_
+#define BH_D2_STORM_FUNCTION_V1_00_FILE_READ_FILE_HPP_
+
+#include <stdint.h>
+#include <windows.h>
+
+namespace bh::d2::storm::v1_00 {
+
+uint32_t SFileReadFile(
+    HANDLE file,
+    void* buffer,
+    uint32_t buffer_size,
+    uint32_t* read_count,
+    OVERLAPPED* overlapped);
+
+}  // namespace bh::d2::storm::v1_00
+
+#endif  // BH_D2_STORM_FUNCTION_V1_00_FILE_READ_FILE_HPP_
+


### PR DESCRIPTION
These changes move all Storm variables/functions out of D2Ptrs and into separate files with a consistent interface.