### PR TITLE
Fix temp ref return

### DIFF
--- a/src/bh/d2/dll/path.cpp
+++ b/src/bh/d2/dll/path.cpp
@@ -99,7 +99,8 @@ static std::array<wchar_t, MAX_PATH>& GetNativeAbsolutePath(Dll dll) {
         __LINE__,
         "Unhandled Dll with value {:d}.",
         static_cast<int>(dll));
-    return PathType();
+    static PathType kDummyValue;
+    return kDummyValue;
   }
 
   // Init the path, if is hasn't yet.

--- a/src/bh/d2/storm/function/v1_12/file_close_file.hpp
+++ b/src/bh/d2/storm/function/v1_12/file_close_file.hpp
@@ -1,4 +1,3 @@
-
 /**
  * SlashDiablo Maphack
  * Copyright (C) 2012-2022  SlashDiablo Team


### PR DESCRIPTION
These changes fix a compile VS2019 caused by returning a reference to a temporary.