### PR TITLE
Move common to a separate library from core BH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,4 +59,4 @@ target_include_directories(${PROJECT_NAME}
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/cpp-lru-cache/include
         ${CMAKE_CURRENT_SOURCE_DIR}/src)
-target_link_libraries(${PROJECT_NAME} shlwapi version)
+target_link_libraries(${PROJECT_NAME} shlwapi version BH.Common)

--- a/src/bh/common/CMakeLists.txt
+++ b/src/bh/common/CMakeLists.txt
@@ -17,6 +17,29 @@
 # License along with this program.  If not, see
 # <http://www.gnu.org/licenses/>.
 
+cmake_minimum_required(VERSION 3.24)
+
+# Name of the project, also is the name of the file
+project(BH.Common)
+
+# Define requirements for C
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+# Define requirements for C++
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Remove MinGW compiled binary "lib" prefix
+if (MINGW)
+    set(CMAKE_IMPORT_LIBRARY_PREFIX "")
+    set(CMAKE_SHARED_LIBRARY_PREFIX "")
+    set(CMAKE_STATIC_LIBRARY_PREFIX "")
+endif (MINGW)
+
+# Define DLL target
+add_library(${PROJECT_NAME} STATIC)
+
 target_sources(${PROJECT_NAME}
     PRIVATE
         "${CMAKE_CURRENT_SOURCE_DIR}/input.cpp"
@@ -26,3 +49,8 @@ target_sources(${PROJECT_NAME}
 add_subdirectory("logging")
 add_subdirectory("string_util")
 add_subdirectory("windows")
+
+target_compile_definitions(${PROJECT_NAME} PRIVATE NOMINMAX)
+target_include_directories(${PROJECT_NAME}
+    PUBLIC
+        "${CMAKE_SOURCE_DIR}/src")

--- a/src/bh/common/README.md
+++ b/src/bh/common/README.md
@@ -1,0 +1,2 @@
+# BH Common Utilities
+This directory is a collection of common utility functions that are generally useful. They should not contain any dependencies on Diablo II functionality.


### PR DESCRIPTION
This forces a one-direction dependency on the common portion of the BH code.