### PR TITLE
Reduce template params

### DIFF
--- a/src/bh/common/string_util/ascii.c
+++ b/src/bh/common/string_util/ascii.c
@@ -31,88 +31,54 @@
 #include <stddef.h>
 #include <wchar.h>
 
+#include "bh/common/string_util/internal/ascii/to_lower_char.h"
+#include "bh/common/string_util/internal/ascii/to_lower_str.h"
+#include "bh/common/string_util/internal/ascii/to_upper_char.h"
+#include "bh/common/string_util/internal/ascii/to_upper_str.h"
+#include "bh/common/string_util/internal/ascii/trim_whitespace_chars.h"
 #include "bh/common/string_util/memstring.h"
 
 /**
  * External
  */
 
-/**
- * Define Ascii_ToLowerChar
- */
+char Ascii_ToLowerChar(char ch) {
+  return T_Ascii_ToLowerChar(char)(ch);
+}
 
-#define T_CHAR char
-#define T_STR_LITERAL_PREFIX
-#define T_FUNC_NAME Ascii_ToLowerChar
-#include "bh/common/string_util/internal/ascii/to_lower_char_template.h"
+wchar_t Ascii_ToLowerWChar(wchar_t ch) {
+  return T_Ascii_ToLowerChar(wchar_t)(ch);
+}
 
-#define T_CHAR wchar_t
-#define T_STR_LITERAL_PREFIX L
-#define T_FUNC_NAME Ascii_ToLowerWChar
-#include "bh/common/string_util/internal/ascii/to_lower_char_template.h"
+char* Ascii_ToLowerStr(char* dest, const char* src, size_t length) {
+  return T_Ascii_ToLowerStr(char)(dest, src, length);
+}
 
-/**
- * Define Ascii_ToLowerStr
- */
+wchar_t* Ascii_ToLowerWStr(wchar_t* dest, const wchar_t* src, size_t length) {
+  return T_Ascii_ToLowerStr(wchar_t)(dest, src, length);
+}
 
-#define T_CHAR char
-#define T_STR_LITERAL_PREFIX
-#define T_TO_LOWER_CHAR_FUNC_NAME Ascii_ToLowerChar
-#define T_FUNC_NAME Ascii_ToLowerStr
-#include "bh/common/string_util/internal/ascii/to_lower_str_template.h"
+char Ascii_ToUpperChar(char ch) {
+  return T_Ascii_ToUpperChar(char)(ch);
+}
 
-#define T_CHAR wchar_t
-#define T_STR_LITERAL_PREFIX L
-#define T_TO_LOWER_CHAR_FUNC_NAME Ascii_ToLowerWChar
-#define T_FUNC_NAME Ascii_ToLowerWStr
-#include "bh/common/string_util/internal/ascii/to_lower_str_template.h"
+wchar_t Ascii_ToUpperWChar(wchar_t ch) {
+  return T_Ascii_ToUpperChar(wchar_t)(ch);
+}
 
-/**
- * Define Ascii_ToUpperChar
- */
+char* Ascii_ToUpperStr(char* dest, const char* src, size_t length) {
+  return T_Ascii_ToUpperStr(char)(dest, src, length);
+}
 
-#define T_CHAR char
-#define T_STR_LITERAL_PREFIX
-#define T_FUNC_NAME Ascii_ToUpperChar
-#include "bh/common/string_util/internal/ascii/to_upper_char_template.h"
+wchar_t* Ascii_ToUpperWStr(wchar_t* dest, const wchar_t* src, size_t length) {
+  return T_Ascii_ToUpperStr(wchar_t)(dest, src, length);
+}
 
-#define T_CHAR wchar_t
-#define T_STR_LITERAL_PREFIX L
-#define T_FUNC_NAME Ascii_ToUpperWChar
-#include "bh/common/string_util/internal/ascii/to_upper_char_template.h"
+char* Ascii_TrimWhitespaceChars(char* dest, const char* src, size_t length) {
+  return T_Ascii_TrimWhitespaceChars(char)(dest, src, length);
+}
 
-/**
- * Define Ascii_ToUpperStr
- */
-
-#define T_CHAR char
-#define T_STR_LITERAL_PREFIX
-#define T_TO_UPPER_CHAR_FUNC_NAME Ascii_ToUpperChar
-#define T_FUNC_NAME Ascii_ToUpperStr
-#include "bh/common/string_util/internal/ascii/to_upper_str_template.h"
-
-#define T_CHAR wchar_t
-#define T_STR_LITERAL_PREFIX L
-#define T_TO_UPPER_CHAR_FUNC_NAME Ascii_ToUpperWChar
-#define T_FUNC_NAME Ascii_ToUpperWStr
-#include "bh/common/string_util/internal/ascii/to_upper_str_template.h"
-
-/**
- * Define Ascii_TrimWhitespaceChars
- */
-
-#define T_CHAR char
-#define T_STR_LITERAL_PREFIX
-#define T_MEMCRSPN_FUNC_NAME MemCRSpn
-#define T_MEMCPY_FUNC_NAME memcpy
-#define T_MEMCSPN_FUNC_NAME MemCSpn
-#define T_FUNC_NAME Ascii_TrimWhitespaceChars
-#include "bh/common/string_util/internal/ascii/trim_whitespace_chars_template.h"
-
-#define T_CHAR wchar_t
-#define T_STR_LITERAL_PREFIX L
-#define T_MEMCRSPN_FUNC_NAME WMemCRSpn
-#define T_MEMCPY_FUNC_NAME wmemcpy
-#define T_MEMCSPN_FUNC_NAME WMemCSpn
-#define T_FUNC_NAME Ascii_TrimWhitespaceWChars
-#include "bh/common/string_util/internal/ascii/trim_whitespace_chars_template.h"
+wchar_t* Ascii_TrimWhitespaceWChars(
+    wchar_t* dest, const wchar_t* src, size_t length) {
+  return T_Ascii_TrimWhitespaceChars(wchar_t)(dest, src, length);
+}

--- a/src/bh/common/string_util/bool.c
+++ b/src/bh/common/string_util/bool.c
@@ -32,79 +32,41 @@
 #include <wchar.h>
 
 #include "bh/common/string_util/ascii.h"
+#include "bh/common/string_util/internal/bool/from_true_false_str.h"
+#include "bh/common/string_util/internal/bool/to_true_false_str.h"
 
 /**
  * External
  */
 
-/**
- * Define Bool_FromTrueFalseStr
- */
+int* Bool_FromOnOffStr(int* dest, const char* src, size_t length) {
+  return T_Bool_FromOnOffStr(char)(dest, src, length);
+}
 
-#define T_CHAR char
-#define T_STR_LITERAL_PREFIX
-#define T_TRUE_STR_LITERAL "on"
-#define T_FALSE_STR_LITERAL "off"
-#define T_TO_LOWER_STR_FUNC_NAME Ascii_ToLowerStr
-#define T_MEMCMP_FUNC_NAME memcmp
-#define T_FUNC_NAME Bool_FromOnOffStr
-#include "bh/common/string_util/internal/bool/from_true_false_str_template.h"
+int* Bool_FromOnOffWStr(int* dest, const wchar_t* src, size_t length) {
+  return T_Bool_FromOnOffStr(wchar_t)(dest, src, length);
+}
 
-#define T_CHAR wchar_t
-#define T_STR_LITERAL_PREFIX L
-#define T_TRUE_STR_LITERAL "on"
-#define T_FALSE_STR_LITERAL "off"
-#define T_TO_LOWER_STR_FUNC_NAME Ascii_ToLowerWStr
-#define T_MEMCMP_FUNC_NAME wmemcmp
-#define T_FUNC_NAME Bool_FromOnOffWStr
-#include "bh/common/string_util/internal/bool/from_true_false_str_template.h"
+int* Bool_FromTrueFalseStr(int* dest, const char* src, size_t length) {
+  return T_Bool_FromTrueFalseStr(char)(dest, src, length);
+}
 
-#define T_CHAR char
-#define T_STR_LITERAL_PREFIX
-#define T_TRUE_STR_LITERAL "true"
-#define T_FALSE_STR_LITERAL "false"
-#define T_TO_LOWER_STR_FUNC_NAME Ascii_ToLowerStr
-#define T_MEMCMP_FUNC_NAME memcmp
-#define T_FUNC_NAME Bool_FromTrueFalseStr
-#include "bh/common/string_util/internal/bool/from_true_false_str_template.h"
+int* Bool_FromTrueFalseWStr(int* dest, const wchar_t* src, size_t length) {
+  return T_Bool_FromTrueFalseStr(wchar_t)(dest, src, length);
+}
 
-#define T_CHAR wchar_t
-#define T_STR_LITERAL_PREFIX L
-#define T_TRUE_STR_LITERAL "true"
-#define T_FALSE_STR_LITERAL "false"
-#define T_TO_LOWER_STR_FUNC_NAME Ascii_ToLowerWStr
-#define T_MEMCMP_FUNC_NAME wmemcmp
-#define T_FUNC_NAME Bool_FromTrueFalseWStr
-#include "bh/common/string_util/internal/bool/from_true_false_str_template.h"
+const char* Bool_ToOnOffStr(int value, size_t* length) {
+  return T_Bool_ToOnOffStr(char)(value, length);
+}
 
-/**
- * Define Bool_ToTrueFalseStr
- */
+const wchar_t* Bool_ToOnOffWStr(int value, size_t* length) {
+  return T_Bool_ToOnOffStr(wchar_t)(value, length);
+}
 
-#define T_CHAR char
-#define T_STR_LITERAL_PREFIX
-#define T_TRUE_STR_LITERAL "on"
-#define T_FALSE_STR_LITERAL "off"
-#define T_FUNC_NAME Bool_ToOnOffStr
-#include "bh/common/string_util/internal/bool/to_true_false_str_template.h"
+const char* Bool_ToTrueFalseStr(int value, size_t* length) {
+  return T_Bool_ToTrueFalseStr(char)(value, length);
+}
 
-#define T_CHAR wchar_t
-#define T_STR_LITERAL_PREFIX L
-#define T_TRUE_STR_LITERAL "on"
-#define T_FALSE_STR_LITERAL "off"
-#define T_FUNC_NAME Bool_ToOnOffWStr
-#include "bh/common/string_util/internal/bool/to_true_false_str_template.h"
-
-#define T_CHAR char
-#define T_STR_LITERAL_PREFIX
-#define T_TRUE_STR_LITERAL "true"
-#define T_FALSE_STR_LITERAL "false"
-#define T_FUNC_NAME Bool_ToTrueFalseStr
-#include "bh/common/string_util/internal/bool/to_true_false_str_template.h"
-
-#define T_CHAR wchar_t
-#define T_STR_LITERAL_PREFIX L
-#define T_TRUE_STR_LITERAL "true"
-#define T_FALSE_STR_LITERAL "false"
-#define T_FUNC_NAME Bool_ToTrueFalseWStr
-#include "bh/common/string_util/internal/bool/to_true_false_str_template.h"
+const wchar_t* Bool_ToTrueFalseWStr(int value, size_t* length) {
+  return T_Bool_ToTrueFalseStr(wchar_t)(value, length);
+}

--- a/src/bh/common/string_util/internal/CMakeLists.txt
+++ b/src/bh/common/string_util/internal/CMakeLists.txt
@@ -18,4 +18,5 @@
 # <http://www.gnu.org/licenses/>.
 
 add_subdirectory("ascii")
+add_subdirectory("bool")
 add_subdirectory("memstring")

--- a/src/bh/common/string_util/internal/ascii/CMakeLists.txt
+++ b/src/bh/common/string_util/internal/ascii/CMakeLists.txt
@@ -19,9 +19,23 @@
 
 target_sources(${PROJECT_NAME}
     PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/to_lower_char.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/to_lower_char.h"
         "${CMAKE_CURRENT_SOURCE_DIR}/to_lower_char_template.h"
+
+        "${CMAKE_CURRENT_SOURCE_DIR}/to_lower_str.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/to_lower_str.h"
         "${CMAKE_CURRENT_SOURCE_DIR}/to_lower_str_template.h"
+
+        "${CMAKE_CURRENT_SOURCE_DIR}/to_upper_char.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/to_upper_char.h"
         "${CMAKE_CURRENT_SOURCE_DIR}/to_upper_char_template.h"
+
+        "${CMAKE_CURRENT_SOURCE_DIR}/to_upper_str.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/to_upper_str.h"
         "${CMAKE_CURRENT_SOURCE_DIR}/to_upper_str_template.h"
+
+        "${CMAKE_CURRENT_SOURCE_DIR}/trim_whitespace_chars.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/trim_whitespace_chars.h"
         "${CMAKE_CURRENT_SOURCE_DIR}/trim_whitespace_chars_template.h"
 )

--- a/src/bh/common/string_util/internal/ascii/to_lower_char.c
+++ b/src/bh/common/string_util/internal/ascii/to_lower_char.c
@@ -28,25 +28,16 @@
 
 #include "bh/common/string_util/internal/ascii/to_lower_char.h"
 
-#include "bh/common/preprocessor/concat.h"
+#include <wchar.h>
 
-#if !defined(T_CHAR)
-#error Define T_CHAR to specify the templated character type.
-#endif  /* !defined(T_CHAR) */
+/**
+ * External
+ */
 
-#if !defined(T_STR_LITERAL_PREFIX)
-#error Define T_STR_LITERAL_PREFIX to specify the templated string literal prefix.
-#endif  /* !defined(T_STR_LITERAL_PREFIX) */
+#define T_CHAR char
+#define T_STR_LITERAL_PREFIX
+#include "bh/common/string_util/internal/ascii/to_lower_char_template.h"
 
-#define TEXT_LITERAL(lit) PREPROCESSOR_CONCAT(T_STR_LITERAL_PREFIX, lit)
-
-T_CHAR T_Ascii_ToLowerChar(T_CHAR)(T_CHAR ch) {
-  return (ch >= TEXT_LITERAL('A') && ch <= TEXT_LITERAL('Z'))
-      ? ch + (TEXT_LITERAL('a') - TEXT_LITERAL('A'))
-      : ch;
-}
-
-#undef TEXT_LITERAL
-
-#undef T_STR_LITERAL_PREFIX
-#undef T_CHAR
+#define T_CHAR wchar_t
+#define T_STR_LITERAL_PREFIX L
+#include "bh/common/string_util/internal/ascii/to_lower_char_template.h"

--- a/src/bh/common/string_util/internal/ascii/to_lower_char.h
+++ b/src/bh/common/string_util/internal/ascii/to_lower_char.h
@@ -26,27 +26,25 @@
  * All rights reserved.
  */
 
-#include "bh/common/string_util/internal/ascii/to_lower_char.h"
+#ifndef BH_COMMON_STRING_UTIL_INTERNAL_ASCII_TO_LOWER_CHAR_H_
+#define BH_COMMON_STRING_UTIL_INTERNAL_ASCII_TO_LOWER_CHAR_H_
 
-#include "bh/common/preprocessor/concat.h"
+#include <wchar.h>
 
-#if !defined(T_CHAR)
-#error Define T_CHAR to specify the templated character type.
-#endif  /* !defined(T_CHAR) */
+#include "bh/common/preprocessor/template/identifier.h"
 
-#if !defined(T_STR_LITERAL_PREFIX)
-#error Define T_STR_LITERAL_PREFIX to specify the templated string literal prefix.
-#endif  /* !defined(T_STR_LITERAL_PREFIX) */
+#ifdef __cplusplus
+extern "C" {
+#endif  /* __cplusplus */
 
-#define TEXT_LITERAL(lit) PREPROCESSOR_CONCAT(T_STR_LITERAL_PREFIX, lit)
+#define T_Ascii_ToLowerChar(T_CHAR) \
+    TEMPLATE_IDENTIFIER_1(T_Ascii_ToLowerChar, T_CHAR)
 
-T_CHAR T_Ascii_ToLowerChar(T_CHAR)(T_CHAR ch) {
-  return (ch >= TEXT_LITERAL('A') && ch <= TEXT_LITERAL('Z'))
-      ? ch + (TEXT_LITERAL('a') - TEXT_LITERAL('A'))
-      : ch;
-}
+char T_Ascii_ToLowerChar(char)(char ch);
+wchar_t T_Ascii_ToLowerChar(wchar_t)(wchar_t ch);
 
-#undef TEXT_LITERAL
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif  /* __cplusplus */
 
-#undef T_STR_LITERAL_PREFIX
-#undef T_CHAR
+#endif  /* BH_COMMON_STRING_UTIL_INTERNAL_ASCII_TO_LOWER_CHAR_H_ */

--- a/src/bh/common/string_util/internal/ascii/to_lower_str.c
+++ b/src/bh/common/string_util/internal/ascii/to_lower_str.c
@@ -26,27 +26,18 @@
  * All rights reserved.
  */
 
-#include "bh/common/string_util/internal/ascii/to_lower_char.h"
+#include "bh/common/string_util/internal/ascii/to_lower_str.h"
 
-#include "bh/common/preprocessor/concat.h"
+#include <wchar.h>
 
-#if !defined(T_CHAR)
-#error Define T_CHAR to specify the templated character type.
-#endif  /* !defined(T_CHAR) */
+/**
+ * External
+ */
 
-#if !defined(T_STR_LITERAL_PREFIX)
-#error Define T_STR_LITERAL_PREFIX to specify the templated string literal prefix.
-#endif  /* !defined(T_STR_LITERAL_PREFIX) */
+#define T_CHAR char
+#define T_STR_LITERAL_PREFIX
+#include "bh/common/string_util/internal/ascii/to_lower_str_template.h"
 
-#define TEXT_LITERAL(lit) PREPROCESSOR_CONCAT(T_STR_LITERAL_PREFIX, lit)
-
-T_CHAR T_Ascii_ToLowerChar(T_CHAR)(T_CHAR ch) {
-  return (ch >= TEXT_LITERAL('A') && ch <= TEXT_LITERAL('Z'))
-      ? ch + (TEXT_LITERAL('a') - TEXT_LITERAL('A'))
-      : ch;
-}
-
-#undef TEXT_LITERAL
-
-#undef T_STR_LITERAL_PREFIX
-#undef T_CHAR
+#define T_CHAR wchar_t
+#define T_STR_LITERAL_PREFIX L
+#include "bh/common/string_util/internal/ascii/to_lower_str_template.h"

--- a/src/bh/common/string_util/internal/ascii/to_lower_str.h
+++ b/src/bh/common/string_util/internal/ascii/to_lower_str.h
@@ -26,27 +26,27 @@
  * All rights reserved.
  */
 
-#include "bh/common/string_util/internal/ascii/to_lower_char.h"
+#ifndef BH_COMMON_STRING_UTIL_INTERNAL_ASCII_TO_LOWER_STR_H_
+#define BH_COMMON_STRING_UTIL_INTERNAL_ASCII_TO_LOWER_STR_H_
 
-#include "bh/common/preprocessor/concat.h"
+#include <stddef.h>
+#include <wchar.h>
 
-#if !defined(T_CHAR)
-#error Define T_CHAR to specify the templated character type.
-#endif  /* !defined(T_CHAR) */
+#include "bh/common/preprocessor/template/identifier.h"
 
-#if !defined(T_STR_LITERAL_PREFIX)
-#error Define T_STR_LITERAL_PREFIX to specify the templated string literal prefix.
-#endif  /* !defined(T_STR_LITERAL_PREFIX) */
+#ifdef __cplusplus
+extern "C" {
+#endif  /* __cplusplus */
 
-#define TEXT_LITERAL(lit) PREPROCESSOR_CONCAT(T_STR_LITERAL_PREFIX, lit)
+#define T_Ascii_ToLowerStr(T_CHAR) \
+    TEMPLATE_IDENTIFIER_1(T_Ascii_ToLowerStr, T_CHAR)
 
-T_CHAR T_Ascii_ToLowerChar(T_CHAR)(T_CHAR ch) {
-  return (ch >= TEXT_LITERAL('A') && ch <= TEXT_LITERAL('Z'))
-      ? ch + (TEXT_LITERAL('a') - TEXT_LITERAL('A'))
-      : ch;
-}
+char* T_Ascii_ToLowerStr(char)(char* dest, const char* src, size_t length);
+wchar_t* T_Ascii_ToLowerStr(wchar_t)(
+    wchar_t* dest, const wchar_t* src, size_t length);
 
-#undef TEXT_LITERAL
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif  /* __cplusplus */
 
-#undef T_STR_LITERAL_PREFIX
-#undef T_CHAR
+#endif  /* BH_COMMON_STRING_UTIL_INTERNAL_ASCII_TO_LOWER_STR_H_ */

--- a/src/bh/common/string_util/internal/ascii/to_lower_str_template.h
+++ b/src/bh/common/string_util/internal/ascii/to_lower_str_template.h
@@ -28,6 +28,10 @@
 
 #include <stddef.h>
 
+#include "bh/common/preprocessor/concat.h"
+#include "bh/common/string_util/internal/ascii/to_lower_char.h"
+#include "bh/common/string_util/internal/ascii/to_lower_str.h"
+
 #if !defined(T_CHAR)
 #error Define T_CHAR to specify the templated character type.
 #endif  /* !defined(T_CHAR) */
@@ -36,23 +40,14 @@
 #error Define T_STR_LITERAL_PREFIX to specify the templated string literal prefix.
 #endif  /* !defined(T_STR_LITERAL_PREFIX) */
 
-#if !defined(T_TO_LOWER_CHAR_FUNC_NAME)
-#error Define T_TO_LOWER_CHAR_FUNC_NAME to specify the Ascii_ToLowerChar function name.
-#endif  /* !defined(T_TO_LOWER_CHAR_FUNC_NAME) */
+#define TEXT_LITERAL(lit) PREPROCESSOR_CONCAT(T_STR_LITERAL_PREFIX, lit)
 
-#if !defined(T_FUNC_NAME)
-#error Define T_FUNC_NAME to specify the function name.
-#endif  /* !defined(T_FUNC_NAME) */
-
-#define CONCAT_IMPL(a, b) a ## b
-#define CONCAT(a, b) CONCAT_IMPL(a, b)
-#define TEXT_LITERAL(lit) CONCAT(T_STR_LITERAL_PREFIX, lit)
-
-T_CHAR* T_FUNC_NAME(T_CHAR* dest, const T_CHAR* src, size_t length) {
+T_CHAR* T_Ascii_ToLowerStr(T_CHAR)(
+    T_CHAR* dest, const T_CHAR* src, size_t length) {
   size_t i;
 
   for (i = 0; i < length; ++i) {
-    dest[i] = T_TO_LOWER_CHAR_FUNC_NAME(src[i]);
+    dest[i] = T_Ascii_ToLowerChar(T_CHAR)(src[i]);
   }
   dest[i] = TEXT_LITERAL('\0');
 
@@ -60,10 +55,6 @@ T_CHAR* T_FUNC_NAME(T_CHAR* dest, const T_CHAR* src, size_t length) {
 }
 
 #undef TEXT_LITERAL
-#undef CONCAT
-#undef CONCAT_IMPL
 
-#undef T_FUNC_NAME
-#undef T_TO_LOWER_CHAR_FUNC_NAME
 #undef T_STR_LITERAL_PREFIX
 #undef T_CHAR

--- a/src/bh/common/string_util/internal/ascii/to_upper_char.c
+++ b/src/bh/common/string_util/internal/ascii/to_upper_char.c
@@ -26,27 +26,18 @@
  * All rights reserved.
  */
 
-#include "bh/common/string_util/internal/ascii/to_lower_char.h"
+#include "bh/common/string_util/internal/ascii/to_upper_char.h"
 
-#include "bh/common/preprocessor/concat.h"
+#include <wchar.h>
 
-#if !defined(T_CHAR)
-#error Define T_CHAR to specify the templated character type.
-#endif  /* !defined(T_CHAR) */
+/**
+ * External
+ */
 
-#if !defined(T_STR_LITERAL_PREFIX)
-#error Define T_STR_LITERAL_PREFIX to specify the templated string literal prefix.
-#endif  /* !defined(T_STR_LITERAL_PREFIX) */
+#define T_CHAR char
+#define T_STR_LITERAL_PREFIX
+#include "bh/common/string_util/internal/ascii/to_upper_char_template.h"
 
-#define TEXT_LITERAL(lit) PREPROCESSOR_CONCAT(T_STR_LITERAL_PREFIX, lit)
-
-T_CHAR T_Ascii_ToLowerChar(T_CHAR)(T_CHAR ch) {
-  return (ch >= TEXT_LITERAL('A') && ch <= TEXT_LITERAL('Z'))
-      ? ch + (TEXT_LITERAL('a') - TEXT_LITERAL('A'))
-      : ch;
-}
-
-#undef TEXT_LITERAL
-
-#undef T_STR_LITERAL_PREFIX
-#undef T_CHAR
+#define T_CHAR wchar_t
+#define T_STR_LITERAL_PREFIX L
+#include "bh/common/string_util/internal/ascii/to_upper_char_template.h"

--- a/src/bh/common/string_util/internal/ascii/to_upper_char.h
+++ b/src/bh/common/string_util/internal/ascii/to_upper_char.h
@@ -26,27 +26,25 @@
  * All rights reserved.
  */
 
-#include "bh/common/string_util/internal/ascii/to_lower_char.h"
+#ifndef BH_COMMON_STRING_UTIL_INTERNAL_ASCII_TO_UPPER_CHAR_H_
+#define BH_COMMON_STRING_UTIL_INTERNAL_ASCII_TO_UPPER_CHAR_H_
 
-#include "bh/common/preprocessor/concat.h"
+#include <wchar.h>
 
-#if !defined(T_CHAR)
-#error Define T_CHAR to specify the templated character type.
-#endif  /* !defined(T_CHAR) */
+#include "bh/common/preprocessor/template/identifier.h"
 
-#if !defined(T_STR_LITERAL_PREFIX)
-#error Define T_STR_LITERAL_PREFIX to specify the templated string literal prefix.
-#endif  /* !defined(T_STR_LITERAL_PREFIX) */
+#ifdef __cplusplus
+extern "C" {
+#endif  /* __cplusplus */
 
-#define TEXT_LITERAL(lit) PREPROCESSOR_CONCAT(T_STR_LITERAL_PREFIX, lit)
+#define T_Ascii_ToUpperChar(T_CHAR) \
+    TEMPLATE_IDENTIFIER_1(T_Ascii_ToUpperChar, T_CHAR)
 
-T_CHAR T_Ascii_ToLowerChar(T_CHAR)(T_CHAR ch) {
-  return (ch >= TEXT_LITERAL('A') && ch <= TEXT_LITERAL('Z'))
-      ? ch + (TEXT_LITERAL('a') - TEXT_LITERAL('A'))
-      : ch;
-}
+char T_Ascii_ToUpperChar(char)(char ch);
+wchar_t T_Ascii_ToUpperChar(wchar_t)(wchar_t ch);
 
-#undef TEXT_LITERAL
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif  /* __cplusplus */
 
-#undef T_STR_LITERAL_PREFIX
-#undef T_CHAR
+#endif  /* BH_COMMON_STRING_UTIL_INTERNAL_ASCII_TO_UPPER_CHAR_H_ */

--- a/src/bh/common/string_util/internal/ascii/to_upper_char_template.h
+++ b/src/bh/common/string_util/internal/ascii/to_upper_char_template.h
@@ -26,6 +26,8 @@
  * All rights reserved.
  */
 
+#include "bh/common/string_util/internal/ascii/to_upper_char.h"
+
 #if !defined(T_CHAR)
 #error Define T_CHAR to specify the templated character type.
 #endif  /* !defined(T_CHAR) */
@@ -34,24 +36,15 @@
 #error Define T_STR_LITERAL_PREFIX to specify the templated string literal prefix.
 #endif  /* !defined(T_STR_LITERAL_PREFIX) */
 
-#if !defined(T_FUNC_NAME)
-#error Define T_FUNC_NAME to specify the function name.
-#endif  /* !defined(T_FUNC_NAME) */
+#define TEXT_LITERAL(lit) PREPROCESSOR_CONCAT(T_STR_LITERAL_PREFIX, lit)
 
-#define CONCAT_IMPL(a, b) a ## b
-#define CONCAT(a, b) CONCAT_IMPL(a, b)
-#define TEXT_LITERAL(lit) CONCAT(T_STR_LITERAL_PREFIX, lit)
-
-T_CHAR T_FUNC_NAME(T_CHAR ch) {
+T_CHAR T_Ascii_ToUpperChar(T_CHAR)(T_CHAR ch) {
   return (ch < TEXT_LITERAL('a') || ch > TEXT_LITERAL('z'))
       ? ch
       : ch - (TEXT_LITERAL('a') - TEXT_LITERAL('A'));
 }
 
 #undef TEXT_LITERAL
-#undef CONCAT
-#undef CONCAT_IMPL
 
-#undef T_FUNC_NAME
 #undef T_STR_LITERAL_PREFIX
 #undef T_CHAR

--- a/src/bh/common/string_util/internal/ascii/to_upper_str.c
+++ b/src/bh/common/string_util/internal/ascii/to_upper_str.c
@@ -26,27 +26,18 @@
  * All rights reserved.
  */
 
-#include "bh/common/string_util/internal/ascii/to_lower_char.h"
+#include "bh/common/string_util/internal/ascii/to_upper_str.h"
 
-#include "bh/common/preprocessor/concat.h"
+#include <wchar.h>
 
-#if !defined(T_CHAR)
-#error Define T_CHAR to specify the templated character type.
-#endif  /* !defined(T_CHAR) */
+/**
+ * External
+ */
 
-#if !defined(T_STR_LITERAL_PREFIX)
-#error Define T_STR_LITERAL_PREFIX to specify the templated string literal prefix.
-#endif  /* !defined(T_STR_LITERAL_PREFIX) */
+#define T_CHAR char
+#define T_STR_LITERAL_PREFIX
+#include "bh/common/string_util/internal/ascii/to_upper_str_template.h"
 
-#define TEXT_LITERAL(lit) PREPROCESSOR_CONCAT(T_STR_LITERAL_PREFIX, lit)
-
-T_CHAR T_Ascii_ToLowerChar(T_CHAR)(T_CHAR ch) {
-  return (ch >= TEXT_LITERAL('A') && ch <= TEXT_LITERAL('Z'))
-      ? ch + (TEXT_LITERAL('a') - TEXT_LITERAL('A'))
-      : ch;
-}
-
-#undef TEXT_LITERAL
-
-#undef T_STR_LITERAL_PREFIX
-#undef T_CHAR
+#define T_CHAR wchar_t
+#define T_STR_LITERAL_PREFIX L
+#include "bh/common/string_util/internal/ascii/to_upper_str_template.h"

--- a/src/bh/common/string_util/internal/ascii/to_upper_str.h
+++ b/src/bh/common/string_util/internal/ascii/to_upper_str.h
@@ -26,27 +26,27 @@
  * All rights reserved.
  */
 
-#include "bh/common/string_util/internal/ascii/to_lower_char.h"
+#ifndef BH_COMMON_STRING_UTIL_INTERNAL_ASCII_TO_UPPER_STR_H_
+#define BH_COMMON_STRING_UTIL_INTERNAL_ASCII_TO_UPPER_STR_H_
 
-#include "bh/common/preprocessor/concat.h"
+#include <stddef.h>
+#include <wchar.h>
 
-#if !defined(T_CHAR)
-#error Define T_CHAR to specify the templated character type.
-#endif  /* !defined(T_CHAR) */
+#include "bh/common/preprocessor/template/identifier.h"
 
-#if !defined(T_STR_LITERAL_PREFIX)
-#error Define T_STR_LITERAL_PREFIX to specify the templated string literal prefix.
-#endif  /* !defined(T_STR_LITERAL_PREFIX) */
+#ifdef __cplusplus
+extern "C" {
+#endif  /* __cplusplus */
 
-#define TEXT_LITERAL(lit) PREPROCESSOR_CONCAT(T_STR_LITERAL_PREFIX, lit)
+#define T_Ascii_ToUpperStr(T_CHAR) \
+    TEMPLATE_IDENTIFIER_1(T_Ascii_ToUpperStr, T_CHAR)
 
-T_CHAR T_Ascii_ToLowerChar(T_CHAR)(T_CHAR ch) {
-  return (ch >= TEXT_LITERAL('A') && ch <= TEXT_LITERAL('Z'))
-      ? ch + (TEXT_LITERAL('a') - TEXT_LITERAL('A'))
-      : ch;
-}
+char* T_Ascii_ToUpperStr(char)(char* dest, const char* src, size_t length);
+wchar_t* T_Ascii_ToUpperStr(wchar_t)(
+    wchar_t* dest, const wchar_t* src, size_t length);
 
-#undef TEXT_LITERAL
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif  /* __cplusplus */
 
-#undef T_STR_LITERAL_PREFIX
-#undef T_CHAR
+#endif  /* BH_COMMON_STRING_UTIL_INTERNAL_ASCII_TO_UPPER_STR_H_ */

--- a/src/bh/common/string_util/internal/ascii/to_upper_str_template.h
+++ b/src/bh/common/string_util/internal/ascii/to_upper_str_template.h
@@ -28,6 +28,10 @@
 
 #include <stddef.h>
 
+#include "bh/common/preprocessor/concat.h"
+#include "bh/common/string_util/internal/ascii/to_upper_char.h"
+#include "bh/common/string_util/internal/ascii/to_upper_str.h"
+
 #if !defined(T_CHAR)
 #error Define T_CHAR to specify the templated character type.
 #endif  /* !defined(T_CHAR) */
@@ -36,23 +40,14 @@
 #error Define T_STR_LITERAL_PREFIX to specify the templated string literal prefix.
 #endif  /* !defined(T_STR_LITERAL_PREFIX) */
 
-#if !defined(T_TO_UPPER_CHAR_FUNC_NAME)
-#error Define T_TO_UPPER_CHAR_FUNC_NAME to specify the Ascii_ToUpperChar function name.
-#endif  /* !defined(T_TO_UPPER_CHAR_FUNC_NAME) */
+#define TEXT_LITERAL(lit) PREPROCESSOR_CONCAT(T_STR_LITERAL_PREFIX, lit)
 
-#if !defined(T_FUNC_NAME)
-#error Define T_FUNC_NAME to specify the function name.
-#endif  /* !defined(T_FUNC_NAME) */
-
-#define CONCAT_IMPL(a, b) a ## b
-#define CONCAT(a, b) CONCAT_IMPL(a, b)
-#define TEXT_LITERAL(lit) CONCAT(T_STR_LITERAL_PREFIX, lit)
-
-T_CHAR* T_FUNC_NAME(T_CHAR* dest, const T_CHAR* src, size_t length) {
+T_CHAR* T_Ascii_ToUpperStr(T_CHAR)(
+    T_CHAR* dest, const T_CHAR* src, size_t length) {
   size_t i;
 
   for (i = 0; i < length; ++i) {
-    dest[i] = T_TO_UPPER_CHAR_FUNC_NAME(src[i]);
+    dest[i] = T_Ascii_ToUpperChar(T_CHAR)(src[i]);
   }
   dest[i] = TEXT_LITERAL('\0');
 
@@ -60,10 +55,6 @@ T_CHAR* T_FUNC_NAME(T_CHAR* dest, const T_CHAR* src, size_t length) {
 }
 
 #undef TEXT_LITERAL
-#undef CONCAT
-#undef CONCAT_IMPL
 
-#undef T_FUNC_NAME
-#undef T_TO_UPPER_CHAR_FUNC_NAME
 #undef T_STR_LITERAL_PREFIX
 #undef T_CHAR

--- a/src/bh/common/string_util/internal/ascii/trim_whitespace_chars.c
+++ b/src/bh/common/string_util/internal/ascii/trim_whitespace_chars.c
@@ -26,27 +26,18 @@
  * All rights reserved.
  */
 
-#include "bh/common/string_util/internal/ascii/to_lower_char.h"
+#include "bh/common/string_util/internal/ascii/trim_whitespace_chars.h"
 
-#include "bh/common/preprocessor/concat.h"
+#include <wchar.h>
 
-#if !defined(T_CHAR)
-#error Define T_CHAR to specify the templated character type.
-#endif  /* !defined(T_CHAR) */
+/**
+ * External
+ */
 
-#if !defined(T_STR_LITERAL_PREFIX)
-#error Define T_STR_LITERAL_PREFIX to specify the templated string literal prefix.
-#endif  /* !defined(T_STR_LITERAL_PREFIX) */
+#define T_CHAR char
+#define T_STR_LITERAL_PREFIX
+#include "bh/common/string_util/internal/ascii/trim_whitespace_chars_template.h"
 
-#define TEXT_LITERAL(lit) PREPROCESSOR_CONCAT(T_STR_LITERAL_PREFIX, lit)
-
-T_CHAR T_Ascii_ToLowerChar(T_CHAR)(T_CHAR ch) {
-  return (ch >= TEXT_LITERAL('A') && ch <= TEXT_LITERAL('Z'))
-      ? ch + (TEXT_LITERAL('a') - TEXT_LITERAL('A'))
-      : ch;
-}
-
-#undef TEXT_LITERAL
-
-#undef T_STR_LITERAL_PREFIX
-#undef T_CHAR
+#define T_CHAR wchar_t
+#define T_STR_LITERAL_PREFIX L
+#include "bh/common/string_util/internal/ascii/trim_whitespace_chars_template.h"

--- a/src/bh/common/string_util/internal/ascii/trim_whitespace_chars.h
+++ b/src/bh/common/string_util/internal/ascii/trim_whitespace_chars.h
@@ -26,27 +26,29 @@
  * All rights reserved.
  */
 
-#include "bh/common/string_util/internal/ascii/to_lower_char.h"
+#ifndef BH_COMMON_STRING_UTIL_INTERNAL_ASCII_TRIM_WHITESPACE_CHARS_H_
+#define BH_COMMON_STRING_UTIL_INTERNAL_ASCII_TRIM_WHITESPACE_CHARS_H_
 
-#include "bh/common/preprocessor/concat.h"
+#include <stddef.h>
+#include <wchar.h>
 
-#if !defined(T_CHAR)
-#error Define T_CHAR to specify the templated character type.
-#endif  /* !defined(T_CHAR) */
+#include "bh/common/preprocessor/template/identifier.h"
 
-#if !defined(T_STR_LITERAL_PREFIX)
-#error Define T_STR_LITERAL_PREFIX to specify the templated string literal prefix.
-#endif  /* !defined(T_STR_LITERAL_PREFIX) */
+#ifdef __cplusplus
+extern "C" {
+#endif  /* __cplusplus */
 
-#define TEXT_LITERAL(lit) PREPROCESSOR_CONCAT(T_STR_LITERAL_PREFIX, lit)
+#define T_Ascii_TrimWhitespaceChars(T_CHAR) \
+    TEMPLATE_IDENTIFIER_1(T_Ascii_TrimWhitespaceChars, T_CHAR)
 
-T_CHAR T_Ascii_ToLowerChar(T_CHAR)(T_CHAR ch) {
-  return (ch >= TEXT_LITERAL('A') && ch <= TEXT_LITERAL('Z'))
-      ? ch + (TEXT_LITERAL('a') - TEXT_LITERAL('A'))
-      : ch;
-}
+char* T_Ascii_TrimWhitespaceChars(char)(
+    char* dest, const char* src, size_t length);
 
-#undef TEXT_LITERAL
+wchar_t* T_Ascii_TrimWhitespaceChars(wchar_t)(
+    wchar_t* dest, const wchar_t* src, size_t length);
 
-#undef T_STR_LITERAL_PREFIX
-#undef T_CHAR
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif  /* __cplusplus */
+
+#endif  /* BH_COMMON_STRING_UTIL_INTERNAL_ASCII_TRIM_WHITESPACE_CHARS_H_ */

--- a/src/bh/common/string_util/internal/ascii/trim_whitespace_chars_template.h
+++ b/src/bh/common/string_util/internal/ascii/trim_whitespace_chars_template.h
@@ -28,6 +28,12 @@
 
 #include <stddef.h>
 
+#include "bh/common/preprocessor/concat.h"
+#include "bh/common/string_util/internal/ascii/trim_whitespace_chars.h"
+#include "bh/common/string_util/internal/memstring/memcpy.h"
+#include "bh/common/string_util/internal/memstring/memcrspn.h"
+#include "bh/common/string_util/internal/memstring/memcspn.h"
+
 #if !defined(T_CHAR)
 #error Define T_CHAR to specify the templated character type.
 #endif  /* !defined(T_CHAR) */
@@ -36,27 +42,10 @@
 #error Define T_STR_LITERAL_PREFIX to specify the templated string literal prefix.
 #endif  /* !defined(T_STR_LITERAL_PREFIX) */
 
-#if !defined(T_MEMCRSPN_FUNC_NAME)
-#error Define T_MEMCRSPN_FUNC_NAME to specify the memcrspn function name.
-#endif  /* !defined(T_MEMCRSPN_FUNC_NAME) */
+#define TEXT_LITERAL(lit) PREPROCESSOR_CONCAT(T_STR_LITERAL_PREFIX, lit)
 
-#if !defined(T_MEMCPY_FUNC_NAME)
-#error Define T_MEMCPY_FUNC_NAME to specify the memcpy function name.
-#endif  /* !defined(T_MEMCPY_FUNC_NAME) */
-
-#if !defined(T_MEMCSPN_FUNC_NAME)
-#error Define T_MEMCSPN_FUNC_NAME to specify the memcspn function name.
-#endif  /* !defined(T_MEMCSPN_FUNC_NAME) */
-
-#if !defined(T_FUNC_NAME)
-#error Define T_FUNC_NAME to specify the function name.
-#endif  /* !defined(T_FUNC_NAME) */
-
-#define CONCAT_IMPL(a, b) a ## b
-#define CONCAT(a, b) CONCAT_IMPL(a, b)
-#define TEXT_LITERAL(lit) CONCAT(T_STR_LITERAL_PREFIX, lit)
-
-T_CHAR* T_FUNC_NAME(T_CHAR* dest, const T_CHAR* src, size_t length) {
+T_CHAR* T_Ascii_TrimWhitespaceChars(T_CHAR)(
+    T_CHAR* dest, const T_CHAR* src, size_t length) {
   static const T_CHAR kWhitespaceChars[] = {
     TEXT_LITERAL(' '),
     TEXT_LITERAL('\f'),
@@ -74,25 +63,21 @@ T_CHAR* T_FUNC_NAME(T_CHAR* dest, const T_CHAR* src, size_t length) {
   size_t i_begin;
   size_t dest_length;
 
-  i_begin = T_MEMCSPN_FUNC_NAME(src, length, kWhitespaceChars, kWhitespaceCharsCount);
+  i_begin =
+      T_MemCSpn(T_CHAR)(src, length, kWhitespaceChars, kWhitespaceCharsCount);
   dest_length =
-      T_MEMCRSPN_FUNC_NAME(
+      T_MemCRSpn(T_CHAR)(
           &src[i_begin],
           length - i_begin,
           kWhitespaceChars,
           kWhitespaceCharsCount);
 
-  T_MEMCPY_FUNC_NAME(dest, &src[i_begin], dest_length + 1);
+  T_MemCpy(T_CHAR)(dest, &src[i_begin], dest_length + 1);
 
   return dest;
 }
 
 #undef TEXT_LITERAL
-#undef CONCAT
-#undef CONCAT_IMPL
-#undef T_FUNC_NAME
-#undef T_MEMCSPN_FUNC_NAME
-#undef T_MEMCPY_FUNC_NAME
-#undef T_MEMCRSPN_FUNC_NAME
+
 #undef T_STR_LITERAL_PREFIX
 #undef T_CHAR

--- a/src/bh/common/string_util/internal/bool/CMakeLists.txt
+++ b/src/bh/common/string_util/internal/bool/CMakeLists.txt
@@ -19,6 +19,11 @@
 
 target_sources(${PROJECT_NAME}
     PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/from_true_false_str.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/from_true_false_str.h"
         "${CMAKE_CURRENT_SOURCE_DIR}/from_true_false_str_template.h"
+
+        "${CMAKE_CURRENT_SOURCE_DIR}/to_true_false_str.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/to_true_false_str.h"
         "${CMAKE_CURRENT_SOURCE_DIR}/to_true_false_str_template.h"
 )

--- a/src/bh/common/string_util/internal/bool/from_true_false_str.c
+++ b/src/bh/common/string_util/internal/bool/from_true_false_str.c
@@ -1,0 +1,59 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2023  SlashDiablo Team
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#include "bh/common/string_util/internal/bool/from_true_false_str.h"
+
+#include <wchar.h>
+
+/**
+ * External
+ */
+
+#define T_CHAR char
+#define T_TRUE_STR_LITERAL "on"
+#define T_FALSE_STR_LITERAL "off"
+#define T_FUNC_NAME T_Bool_FromOnOffStr
+#include "bh/common/string_util/internal/bool/from_true_false_str_template.h"
+
+#define T_CHAR wchar_t
+#define T_TRUE_STR_LITERAL L"on"
+#define T_FALSE_STR_LITERAL L"off"
+#define T_FUNC_NAME T_Bool_FromOnOffStr
+#include "bh/common/string_util/internal/bool/from_true_false_str_template.h"
+
+#define T_CHAR char
+#define T_TRUE_STR_LITERAL "true"
+#define T_FALSE_STR_LITERAL "false"
+#define T_FUNC_NAME T_Bool_FromTrueFalseStr
+#include "bh/common/string_util/internal/bool/from_true_false_str_template.h"
+
+#define T_CHAR wchar_t
+#define T_TRUE_STR_LITERAL L"true"
+#define T_FALSE_STR_LITERAL L"false"
+#define T_FUNC_NAME T_Bool_FromTrueFalseStr
+#include "bh/common/string_util/internal/bool/from_true_false_str_template.h"

--- a/src/bh/common/string_util/internal/bool/from_true_false_str.h
+++ b/src/bh/common/string_util/internal/bool/from_true_false_str.h
@@ -1,0 +1,61 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2023  SlashDiablo Team
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#ifndef BH_COMMON_STRING_UTIL_INTERNAL_BOOL_FROM_TRUE_FALSE_STR_H_
+#define BH_COMMON_STRING_UTIL_INTERNAL_BOOL_FROM_TRUE_FALSE_STR_H_
+
+#include <stddef.h>
+#include <wchar.h>
+
+#include "bh/common/preprocessor/template/identifier.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  /* __cplusplus */
+
+#define T_Bool_FromTrueFalseStr(T_CHAR) \
+    TEMPLATE_IDENTIFIER_1(T_Bool_FromTrueFalseStr, T_CHAR)
+
+#define T_Bool_FromOnOffStr(T_CHAR) \
+    TEMPLATE_IDENTIFIER_1(T_Bool_FromOnOffStr, T_CHAR)
+
+int* T_Bool_FromTrueFalseStr(char)(int* dest, const char* src, size_t length);
+
+int* T_Bool_FromTrueFalseStr(wchar_t)(
+    int* dest, const wchar_t* src, size_t length);
+
+int* T_Bool_FromOnOffStr(char)(int* dest, const char* src, size_t length);
+
+int* T_Bool_FromOnOffStr(wchar_t)(
+    int* dest, const wchar_t* src, size_t length);
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif  /* __cplusplus */
+
+#endif  /* BH_COMMON_STRING_UTIL_INTERNAL_BOOL_FROM_TRUE_FALSE_STR_H_ */

--- a/src/bh/common/string_util/internal/bool/from_true_false_str_template.h
+++ b/src/bh/common/string_util/internal/bool/from_true_false_str_template.h
@@ -29,13 +29,13 @@
 #include <assert.h>
 #include <stddef.h>
 
+#include "bh/common/string_util/internal/ascii/to_lower_str.h"
+#include "bh/common/string_util/internal/bool/from_true_false_str.h"
+#include "bh/common/string_util/internal/memstring/memcmp.h"
+
 #if !defined(T_CHAR)
 #error Define T_CHAR to specify the templated character type.
 #endif  /* !defined(T_CHAR) */
-
-#if !defined(T_STR_LITERAL_PREFIX)
-#error Define T_STR_LITERAL_PREFIX to specify the templated string literal prefix.
-#endif  /* !defined(T_STR_LITERAL_PREFIX) */
 
 #if !defined(T_TRUE_STR_LITERAL)
 #error Define T_TRUE_STR_LITERAL to specify the lowercase string literal for true value.
@@ -45,25 +45,13 @@
 #error Define T_FALSE_STR_LITERAL to specify the lowercase string literal for true value.
 #endif  /* !defined(T_FALSE_STR_LITERAL) */
 
-#if !defined(T_TO_LOWER_STR_FUNC_NAME)
-#error Define T_TO_LOWER_STR_FUNC_NAME to specify the Ascii_ToLowerStr function name.
-#endif  /* !defined(T_TO_LOWER_STR_FUNC_NAME) */
-
-#if !defined(T_MEMCMP_FUNC_NAME)
-#error Define T_MEMCMP_FUNC_NAME to specify the memcmp function name.
-#endif  /* !defined(T_MEMCMP_FUNC_NAME) */
-
 #if !defined(T_FUNC_NAME)
 #error Define T_FUNC_NAME to specify the function name.
 #endif  /* !defined(T_FUNC_NAME) */
 
-#define CONCAT_IMPL(a, b) a ## b
-#define CONCAT(a, b) CONCAT_IMPL(a, b)
-#define TEXT_LITERAL(lit) CONCAT(T_STR_LITERAL_PREFIX, lit)
-
-int* T_FUNC_NAME(int* dest, const T_CHAR* src, size_t length) {
-  static const T_CHAR kTrueStr[] = TEXT_LITERAL(T_TRUE_STR_LITERAL);
-  static const T_CHAR kFalseStr[] = TEXT_LITERAL(T_FALSE_STR_LITERAL);
+int* T_FUNC_NAME(T_CHAR)(int* dest, const T_CHAR* src, size_t length) {
+  static const T_CHAR kTrueStr[] = T_TRUE_STR_LITERAL;
+  static const T_CHAR kFalseStr[] = T_FALSE_STR_LITERAL;
   enum {
     kTrueStrLength = sizeof(kTrueStr) / sizeof(kTrueStr[0]) - 1,
     kFalseStrLength = sizeof(kFalseStr) / sizeof(kFalseStr[0]) - 1,
@@ -74,10 +62,10 @@ int* T_FUNC_NAME(int* dest, const T_CHAR* src, size_t length) {
   const T_CHAR* compare_src;
 
 #if !defined(NDEBUG)
-  T_TO_LOWER_STR_FUNC_NAME(lower_str, kTrueStr, kTrueStrLength);
-  assert(T_MEMCMP_FUNC_NAME(lower_str, kTrueStr, kTrueStrLength) == 0);
-  T_TO_LOWER_STR_FUNC_NAME(lower_str, kFalseStr, kFalseStrLength);
-  assert(T_MEMCMP_FUNC_NAME(lower_str, kFalseStr, kFalseStrLength) == 0);
+  T_Ascii_ToLowerStr(T_CHAR)(lower_str, kTrueStr, kTrueStrLength);
+  assert(T_MemCmp(T_CHAR)(lower_str, kTrueStr, kTrueStrLength) == 0);
+  T_Ascii_ToLowerStr(T_CHAR)(lower_str, kFalseStr, kFalseStrLength);
+  assert(T_MemCmp(T_CHAR)(lower_str, kFalseStr, kFalseStrLength) == 0);
 #endif  /* !defined(NDEBUG) */
 
   if (src == NULL) {
@@ -88,12 +76,12 @@ int* T_FUNC_NAME(int* dest, const T_CHAR* src, size_t length) {
     return NULL;
   }
 
-  T_TO_LOWER_STR_FUNC_NAME(lower_str, src, length);
+  T_Ascii_ToLowerStr(T_CHAR)(lower_str, src, length);
 
-  if (T_MEMCMP_FUNC_NAME(lower_str, kTrueStr, kTrueStrLength) == 0) {
+  if (T_MemCmp(T_CHAR)(lower_str, kTrueStr, kTrueStrLength) == 0) {
     *dest = 1;
     return dest;
-  } else if (T_MEMCMP_FUNC_NAME(lower_str, kFalseStr, kFalseStrLength) == 0) {
+  } else if (T_MemCmp(T_CHAR)(lower_str, kFalseStr, kFalseStrLength) == 0) {
     *dest = 0;
     return dest;
   } else {
@@ -101,17 +89,9 @@ int* T_FUNC_NAME(int* dest, const T_CHAR* src, size_t length) {
   }
 }
 
-#undef TEXT_LITERAL
-#undef CONCAT
-#undef CONCAT_IMPL
-
 #undef T_FUNC_NAME
-
-#undef T_MEMCMP_FUNC_NAME
-#undef T_TO_LOWER_STR_FUNC_NAME
 
 #undef T_FALSE_STR_LITERAL
 #undef T_TRUE_STR_LITERAL
 
-#undef T_STR_LITERAL_PREFIX
 #undef T_CHAR

--- a/src/bh/common/string_util/internal/bool/to_true_false_str.c
+++ b/src/bh/common/string_util/internal/bool/to_true_false_str.c
@@ -1,0 +1,59 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2023  SlashDiablo Team
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#include "bh/common/string_util/internal/bool/to_true_false_str.h"
+
+#include <wchar.h>
+
+/**
+ * External
+ */
+
+#define T_CHAR char
+#define T_TRUE_STR_LITERAL "on"
+#define T_FALSE_STR_LITERAL "off"
+#define T_FUNC_NAME T_Bool_ToOnOffStr
+#include "bh/common/string_util/internal/bool/to_true_false_str_template.h"
+
+#define T_CHAR wchar_t
+#define T_TRUE_STR_LITERAL L"on"
+#define T_FALSE_STR_LITERAL L"off"
+#define T_FUNC_NAME T_Bool_ToOnOffStr
+#include "bh/common/string_util/internal/bool/to_true_false_str_template.h"
+
+#define T_CHAR char
+#define T_TRUE_STR_LITERAL "true"
+#define T_FALSE_STR_LITERAL "false"
+#define T_FUNC_NAME T_Bool_ToTrueFalseStr
+#include "bh/common/string_util/internal/bool/to_true_false_str_template.h"
+
+#define T_CHAR wchar_t
+#define T_TRUE_STR_LITERAL L"true"
+#define T_FALSE_STR_LITERAL L"false"
+#define T_FUNC_NAME T_Bool_ToTrueFalseStr
+#include "bh/common/string_util/internal/bool/to_true_false_str_template.h"

--- a/src/bh/common/string_util/internal/bool/to_true_false_str.h
+++ b/src/bh/common/string_util/internal/bool/to_true_false_str.h
@@ -1,0 +1,59 @@
+/**
+ * SlashDiablo Maphack
+ * Copyright (C) 2012-2023  SlashDiablo Team
+ *
+ * This file is part of SlashDiablo Maphack.
+ *
+ * SlashDiablo Maphack is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BH
+ * Copyright (C) 2011  McGod
+ *
+ * All rights reserved.
+ */
+
+#ifndef BH_COMMON_STRING_UTIL_INTERNAL_BOOL_TO_TRUE_FALSE_STR_H_
+#define BH_COMMON_STRING_UTIL_INTERNAL_BOOL_TO_TRUE_FALSE_STR_H_
+
+#include <stddef.h>
+#include <wchar.h>
+
+#include "bh/common/preprocessor/template/identifier.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  /* __cplusplus */
+
+#define T_Bool_ToTrueFalseStr(T_CHAR) \
+    TEMPLATE_IDENTIFIER_1(T_Bool_ToTrueFalseStr, T_CHAR)
+
+#define T_Bool_ToOnOffStr(T_CHAR) \
+    TEMPLATE_IDENTIFIER_1(T_Bool_ToOnOffStr, T_CHAR)
+
+const char* T_Bool_ToTrueFalseStr(char)(int value, size_t* length);
+
+const wchar_t* T_Bool_ToTrueFalseStr(wchar_t)(int value, size_t* length);
+
+const char* T_Bool_ToOnOffStr(char)(int value, size_t* length);
+
+const wchar_t* T_Bool_ToOnOffStr(wchar_t)(int value, size_t* length);
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif  /* __cplusplus */
+
+#endif  /* BH_COMMON_STRING_UTIL_INTERNAL_BOOL_TO_TRUE_FALSE_STR_H_ */

--- a/src/bh/common/string_util/internal/bool/to_true_false_str_template.h
+++ b/src/bh/common/string_util/internal/bool/to_true_false_str_template.h
@@ -32,29 +32,21 @@
 #error Define T_CHAR to specify the templated character type.
 #endif  /* !defined(T_CHAR) */
 
-#if !defined(T_STR_LITERAL_PREFIX)
-#error Define T_STR_LITERAL_PREFIX to specify the templated string literal prefix.
-#endif  /* !defined(T_STR_LITERAL_PREFIX) */
-
 #if !defined(T_TRUE_STR_LITERAL)
-#error Define T_TRUE_STR_LITERAL to specify the lowercase string literal for the true value.
+#error Define T_TRUE_STR_LITERAL to specify the string literal for the true value.
 #endif  /* !defined(T_TRUE_STR_LITERAL) */
 
 #if !defined(T_FALSE_STR_LITERAL)
-#error Define T_FALSE_STR_LITERAL to specify the lowercase string literal for the false value.
+#error Define T_FALSE_STR_LITERAL to specify the string literal for the false value.
 #endif  /* !defined(T_FALSE_STR_LITERAL) */
 
 #if !defined(T_FUNC_NAME)
 #error Define T_FUNC_NAME to specify the function name.
 #endif  /* !defined(T_FUNC_NAME) */
 
-#define CONCAT_IMPL(a, b) a ## b
-#define CONCAT(a, b) CONCAT_IMPL(a, b)
-#define TEXT_LITERAL(lit) CONCAT(T_STR_LITERAL_PREFIX, lit)
-
-const T_CHAR* T_FUNC_NAME(int value, size_t* length) {
+const T_CHAR* T_FUNC_NAME(T_CHAR)(int value, size_t* length) {
   if (value) {
-    static const T_CHAR kStr[] = TEXT_LITERAL(T_TRUE_STR_LITERAL);
+    static const T_CHAR kStr[] = T_TRUE_STR_LITERAL;
 
     if (length != NULL) {
       *length = sizeof(kStr) / sizeof(kStr[0]) - 1;
@@ -62,7 +54,7 @@ const T_CHAR* T_FUNC_NAME(int value, size_t* length) {
 
     return kStr;
   } else {
-    static const T_CHAR kStr[] = TEXT_LITERAL(T_FALSE_STR_LITERAL);
+    static const T_CHAR kStr[] = T_FALSE_STR_LITERAL;
 
     if (length != NULL) {
       *length = sizeof(kStr) / sizeof(kStr[0]) - 1;
@@ -72,14 +64,9 @@ const T_CHAR* T_FUNC_NAME(int value, size_t* length) {
   }
 }
 
-#undef TEXT_LITERAL
-#undef CONCAT
-#undef CONCAT_IMPL
-
 #undef T_FUNC_NAME
 
 #undef T_FALSE_STR_LITERAL
 #undef T_TRUE_STR_LITERAL
 
-#undef T_STR_LITERAL_PREFIX
 #undef T_CHAR

--- a/src/bh/common/string_util/internal/memstring/CMakeLists.txt
+++ b/src/bh/common/string_util/internal/memstring/CMakeLists.txt
@@ -19,9 +19,32 @@
 
 target_sources(${PROJECT_NAME}
     PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/memchr.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/memchr.h"
+
+        "${CMAKE_CURRENT_SOURCE_DIR}/memcmp.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/memcmp.h"
+
+        "${CMAKE_CURRENT_SOURCE_DIR}/memcpy.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/memcpy.h"
+
+        "${CMAKE_CURRENT_SOURCE_DIR}/memcrspn.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/memcrspn.h"
         "${CMAKE_CURRENT_SOURCE_DIR}/memcrspn_template.h"
+
+        "${CMAKE_CURRENT_SOURCE_DIR}/memcspn.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/memcspn.h"
         "${CMAKE_CURRENT_SOURCE_DIR}/memcspn_template.h"
+
+        "${CMAKE_CURRENT_SOURCE_DIR}/memrspn.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/memrspn.h"
         "${CMAKE_CURRENT_SOURCE_DIR}/memrspn_template.h"
+
+        "${CMAKE_CURRENT_SOURCE_DIR}/memspn.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/memspn.h"
         "${CMAKE_CURRENT_SOURCE_DIR}/memspn_template.h"
+
+        "${CMAKE_CURRENT_SOURCE_DIR}/memstr.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/memstr.h"
         "${CMAKE_CURRENT_SOURCE_DIR}/memstr_template.h"
 )

--- a/src/bh/common/string_util/internal/memstring/memchr.c
+++ b/src/bh/common/string_util/internal/memstring/memchr.c
@@ -19,45 +19,24 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "bh/common/string_util/internal/memstring/memchr.h"
+
 #include <stddef.h>
+#include <string.h>
+#include <wchar.h>
 
-#include "bh/common/string_util/internal/memstring/memrspn.h"
+/**
+ * External
+ */
 
-#if !defined(T_CHAR)
-#error Define T_CHAR to specify the templated character type.
-#endif  /* !defined(T_CHAR) */
-
-size_t T_MemRSpn(T_CHAR)(
-    const T_CHAR* data,
-    size_t data_size,
-    const T_CHAR* search,
-    size_t search_size) {
-  const T_CHAR* str;
-  size_t i_str;
-  const T_CHAR* chars;
-  size_t i_chars;
-
-  if (data_size <= 0) {
-    return data_size;
-  }
-
-  if (search_size <= 0) {
-    return data_size;
-  }
-
-  str = data;
-  chars = search;
-
-  /* Scan str for a character that is in chars. */
-  for (i_str = data_size; i_str-- > 0; ) {
-    for (i_chars = 0; i_chars < search_size; ++i_chars) {
-      if (str[i_str] == chars[i_chars]) {
-        return i_str;
-      }
-    }
-  }
-
-  return data_size;
+void* T_MemChr(void)(const void* data, char ch, size_t count) {
+  return T_MemChr(char)(data, ch, count);
 }
 
-#undef T_CHAR
+char* T_MemChr(char)(const char* data, char ch, size_t count) {
+  return memchr(data, ch, count);
+}
+
+wchar_t* T_MemChr(wchar_t)(const wchar_t* data, wchar_t ch, size_t count) {
+  return wmemchr(data, ch, count);
+}

--- a/src/bh/common/string_util/internal/memstring/memchr.h
+++ b/src/bh/common/string_util/internal/memstring/memchr.h
@@ -19,45 +19,26 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#ifndef BH_COMMON_STRING_UTIL_INTERNAL_MEMSTRING_MEMCHR_H_
+#define BH_COMMON_STRING_UTIL_INTERNAL_MEMSTRING_MEMCHR_H_
+
 #include <stddef.h>
+#include <wchar.h>
 
-#include "bh/common/string_util/internal/memstring/memrspn.h"
+#include "bh/common/preprocessor/template/identifier.h"
 
-#if !defined(T_CHAR)
-#error Define T_CHAR to specify the templated character type.
-#endif  /* !defined(T_CHAR) */
+#ifdef __cplusplus
+extern "C" {
+#endif  /* __cplusplus */
 
-size_t T_MemRSpn(T_CHAR)(
-    const T_CHAR* data,
-    size_t data_size,
-    const T_CHAR* search,
-    size_t search_size) {
-  const T_CHAR* str;
-  size_t i_str;
-  const T_CHAR* chars;
-  size_t i_chars;
+#define T_MemChr(T_CHAR) TEMPLATE_IDENTIFIER_1(T_MemChr, T_CHAR)
 
-  if (data_size <= 0) {
-    return data_size;
-  }
+void* T_MemChr(void)(const void* data, char ch, size_t data_size);
+char* T_MemChr(char)(const char* data, char ch, size_t data_size);
+wchar_t* T_MemChr(wchar_t)(const wchar_t* data, wchar_t ch, size_t data_size);
 
-  if (search_size <= 0) {
-    return data_size;
-  }
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif  /* __cplusplus */
 
-  str = data;
-  chars = search;
-
-  /* Scan str for a character that is in chars. */
-  for (i_str = data_size; i_str-- > 0; ) {
-    for (i_chars = 0; i_chars < search_size; ++i_chars) {
-      if (str[i_str] == chars[i_chars]) {
-        return i_str;
-      }
-    }
-  }
-
-  return data_size;
-}
-
-#undef T_CHAR
+#endif  /* BH_COMMON_STRING_UTIL_INTERNAL_MEMSTRING_MEMCHR_H_ */

--- a/src/bh/common/string_util/internal/memstring/memcmp.c
+++ b/src/bh/common/string_util/internal/memstring/memcmp.c
@@ -19,45 +19,25 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "bh/common/string_util/internal/memstring/memcmp.h"
+
 #include <stddef.h>
+#include <string.h>
+#include <wchar.h>
 
-#include "bh/common/string_util/internal/memstring/memrspn.h"
+/**
+ * External
+ */
 
-#if !defined(T_CHAR)
-#error Define T_CHAR to specify the templated character type.
-#endif  /* !defined(T_CHAR) */
-
-size_t T_MemRSpn(T_CHAR)(
-    const T_CHAR* data,
-    size_t data_size,
-    const T_CHAR* search,
-    size_t search_size) {
-  const T_CHAR* str;
-  size_t i_str;
-  const T_CHAR* chars;
-  size_t i_chars;
-
-  if (data_size <= 0) {
-    return data_size;
-  }
-
-  if (search_size <= 0) {
-    return data_size;
-  }
-
-  str = data;
-  chars = search;
-
-  /* Scan str for a character that is in chars. */
-  for (i_str = data_size; i_str-- > 0; ) {
-    for (i_chars = 0; i_chars < search_size; ++i_chars) {
-      if (str[i_str] == chars[i_chars]) {
-        return i_str;
-      }
-    }
-  }
-
-  return data_size;
+int T_MemCmp(void)(const void* left, const void* right, size_t count) {
+  return T_MemCmp(char)(left, right, count);
 }
 
-#undef T_CHAR
+int T_MemCmp(char)(const char* left, const char* right, size_t count) {
+  return memcmp(left, right, count);
+}
+
+int T_MemCmp(wchar_t)(
+    const wchar_t* left, const wchar_t* right, size_t count) {
+  return wmemcmp(left, right, count);
+}

--- a/src/bh/common/string_util/internal/memstring/memcmp.h
+++ b/src/bh/common/string_util/internal/memstring/memcmp.h
@@ -19,45 +19,26 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#ifndef BH_COMMON_STRING_UTIL_INTERNAL_MEMSTRING_MEMCMP_H_
+#define BH_COMMON_STRING_UTIL_INTERNAL_MEMSTRING_MEMCMP_H_
+
 #include <stddef.h>
+#include <wchar.h>
 
-#include "bh/common/string_util/internal/memstring/memrspn.h"
+#include "bh/common/preprocessor/template/identifier.h"
 
-#if !defined(T_CHAR)
-#error Define T_CHAR to specify the templated character type.
-#endif  /* !defined(T_CHAR) */
+#ifdef __cplusplus
+extern "C" {
+#endif  /* __cplusplus */
 
-size_t T_MemRSpn(T_CHAR)(
-    const T_CHAR* data,
-    size_t data_size,
-    const T_CHAR* search,
-    size_t search_size) {
-  const T_CHAR* str;
-  size_t i_str;
-  const T_CHAR* chars;
-  size_t i_chars;
+#define T_MemCmp(T_INPUT) TEMPLATE_IDENTIFIER_1(T_MemCmp, T_INPUT)
 
-  if (data_size <= 0) {
-    return data_size;
-  }
+int T_MemCmp(void)(const void* left, const void* right, size_t count);
+int T_MemCmp(char)(const char* left, const char* right, size_t count);
+int T_MemCmp(wchar_t)(const wchar_t* left, const wchar_t* right, size_t count);
 
-  if (search_size <= 0) {
-    return data_size;
-  }
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif  /* __cplusplus */
 
-  str = data;
-  chars = search;
-
-  /* Scan str for a character that is in chars. */
-  for (i_str = data_size; i_str-- > 0; ) {
-    for (i_chars = 0; i_chars < search_size; ++i_chars) {
-      if (str[i_str] == chars[i_chars]) {
-        return i_str;
-      }
-    }
-  }
-
-  return data_size;
-}
-
-#undef T_CHAR
+#endif  /* BH_COMMON_STRING_UTIL_INTERNAL_MEMSTRING_MEMCMP_H_ */

--- a/src/bh/common/string_util/internal/memstring/memcpy.c
+++ b/src/bh/common/string_util/internal/memstring/memcpy.c
@@ -19,45 +19,24 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include "bh/common/string_util/internal/memstring/memcpy.h"
+
 #include <stddef.h>
+#include <string.h>
+#include <wchar.h>
 
-#include "bh/common/string_util/internal/memstring/memrspn.h"
+/**
+ * External
+ */
 
-#if !defined(T_CHAR)
-#error Define T_CHAR to specify the templated character type.
-#endif  /* !defined(T_CHAR) */
-
-size_t T_MemRSpn(T_CHAR)(
-    const T_CHAR* data,
-    size_t data_size,
-    const T_CHAR* search,
-    size_t search_size) {
-  const T_CHAR* str;
-  size_t i_str;
-  const T_CHAR* chars;
-  size_t i_chars;
-
-  if (data_size <= 0) {
-    return data_size;
-  }
-
-  if (search_size <= 0) {
-    return data_size;
-  }
-
-  str = data;
-  chars = search;
-
-  /* Scan str for a character that is in chars. */
-  for (i_str = data_size; i_str-- > 0; ) {
-    for (i_chars = 0; i_chars < search_size; ++i_chars) {
-      if (str[i_str] == chars[i_chars]) {
-        return i_str;
-      }
-    }
-  }
-
-  return data_size;
+void* T_MemCpy(void)(void* dest, const void* src, size_t count) {
+  return T_MemCpy(char)(dest, src, count);
 }
 
-#undef T_CHAR
+char* T_MemCpy(char)(char* dest, const char* src, size_t count) {
+  return memcpy(dest, src, count);
+}
+
+wchar_t* T_MemCpy(wchar_t)(wchar_t* dest, const wchar_t* src, size_t count) {
+  return wmemcpy(dest, src, count);
+}

--- a/src/bh/common/string_util/internal/memstring/memcpy.h
+++ b/src/bh/common/string_util/internal/memstring/memcpy.h
@@ -19,45 +19,26 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#ifndef BH_COMMON_STRING_UTIL_INTERNAL_MEMSTRING_MEMCPY_H_
+#define BH_COMMON_STRING_UTIL_INTERNAL_MEMSTRING_MEMCPY_H_
+
 #include <stddef.h>
+#include <wchar.h>
 
-#include "bh/common/string_util/internal/memstring/memrspn.h"
+#include "bh/common/preprocessor/template/identifier.h"
 
-#if !defined(T_CHAR)
-#error Define T_CHAR to specify the templated character type.
-#endif  /* !defined(T_CHAR) */
+#ifdef __cplusplus
+extern "C" {
+#endif  /* __cplusplus */
 
-size_t T_MemRSpn(T_CHAR)(
-    const T_CHAR* data,
-    size_t data_size,
-    const T_CHAR* search,
-    size_t search_size) {
-  const T_CHAR* str;
-  size_t i_str;
-  const T_CHAR* chars;
-  size_t i_chars;
+#define T_MemCpy(T_CHAR) TEMPLATE_IDENTIFIER_1(T_MemCpy, T_CHAR)
 
-  if (data_size <= 0) {
-    return data_size;
-  }
+void* T_MemCpy(void)(void* dest, const void* src, size_t count);
+char* T_MemCpy(char)(char* dest, const char* src, size_t count);
+wchar_t* T_MemCpy(wchar_t)(wchar_t* dest, const wchar_t* src, size_t count);
 
-  if (search_size <= 0) {
-    return data_size;
-  }
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif  /* __cplusplus */
 
-  str = data;
-  chars = search;
-
-  /* Scan str for a character that is in chars. */
-  for (i_str = data_size; i_str-- > 0; ) {
-    for (i_chars = 0; i_chars < search_size; ++i_chars) {
-      if (str[i_str] == chars[i_chars]) {
-        return i_str;
-      }
-    }
-  }
-
-  return data_size;
-}
-
-#undef T_CHAR
+#endif  /* BH_COMMON_STRING_UTIL_INTERNAL_MEMSTRING_MEMCPY_H_ */

--- a/src/bh/common/string_util/internal/memstring/memcrspn.c
+++ b/src/bh/common/string_util/internal/memstring/memcrspn.c
@@ -19,50 +19,24 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#include <stddef.h>
+#include "bh/common/string_util/internal/memstring/memcrspn.h"
 
-#include "bh/common/string_util/internal/memstring/memcspn.h"
+#include <wchar.h>
 
-#if !defined(T_CHAR)
-#error Define T_CHAR to specify the templated character type.
-#endif  /* !defined(T_CHAR) */
+/**
+ * External
+ */
 
-size_t T_MemCSpn(T_CHAR)(
-    const T_CHAR* data,
+size_t T_MemCRSpn(void)(
+    const void* data,
     size_t data_size,
-    const T_CHAR* search,
+    const void* search,
     size_t search_size) {
-  const T_CHAR* str;
-  size_t i_str;
-  const T_CHAR* chars;
-
-  if (data_size <= 0) {
-    return 0;
-  }
-
-  if (search_size <= 0) {
-    return 0;
-  }
-
-  str = data;
-  chars = search;
-
-  /* Scan str for a character that is not in chars. */
-  for (i_str = 0; i_str < data_size; ++i_str) {
-    size_t i_chars;
-
-    for (i_chars = 0; i_chars < search_size; ++i_chars) {
-      if (str[i_str] == chars[i_chars]) {
-        break;
-      }
-    }
-
-    if (i_chars >= search_size) {
-      return i_str;
-    }
-  }
-
-  return data_size;
+  return T_MemCRSpn(char)(data, data_size, search, search_size);
 }
 
-#undef T_CHAR
+#define T_CHAR char
+#include "bh/common/string_util/internal/memstring/memcrspn_template.h"
+
+#define T_CHAR wchar_t
+#include "bh/common/string_util/internal/memstring/memcrspn_template.h"

--- a/src/bh/common/string_util/internal/memstring/memcrspn.h
+++ b/src/bh/common/string_util/internal/memstring/memcrspn.h
@@ -19,50 +19,40 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#ifndef BH_COMMON_STRING_UTIL_INTERNAL_MEMSTRING_MEMCRSPN_H_
+#define BH_COMMON_STRING_UTIL_INTERNAL_MEMSTRING_MEMCRSPN_H_
+
 #include <stddef.h>
+#include <wchar.h>
 
-#include "bh/common/string_util/internal/memstring/memcspn.h"
+#include "bh/common/preprocessor/template/identifier.h"
 
-#if !defined(T_CHAR)
-#error Define T_CHAR to specify the templated character type.
-#endif  /* !defined(T_CHAR) */
+#ifdef __cplusplus
+extern "C" {
+#endif  /* __cplusplus */
 
-size_t T_MemCSpn(T_CHAR)(
-    const T_CHAR* data,
+#define T_MemCRSpn(T_CHAR) TEMPLATE_IDENTIFIER_1(T_MemCRSpn, T_CHAR)
+
+size_t T_MemCRSpn(void)(
+    const void* data,
     size_t data_size,
-    const T_CHAR* search,
-    size_t search_size) {
-  const T_CHAR* str;
-  size_t i_str;
-  const T_CHAR* chars;
+    const void* search,
+    size_t search_size);
 
-  if (data_size <= 0) {
-    return 0;
-  }
+size_t T_MemCRSpn(char)(
+    const char* data,
+    size_t data_size,
+    const char* search,
+    size_t search_size);
 
-  if (search_size <= 0) {
-    return 0;
-  }
+size_t T_MemCRSpn(wchar_t)(
+    const wchar_t* data,
+    size_t data_size,
+    const wchar_t* search,
+    size_t search_size);
 
-  str = data;
-  chars = search;
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif  /* __cplusplus */
 
-  /* Scan str for a character that is not in chars. */
-  for (i_str = 0; i_str < data_size; ++i_str) {
-    size_t i_chars;
-
-    for (i_chars = 0; i_chars < search_size; ++i_chars) {
-      if (str[i_str] == chars[i_chars]) {
-        break;
-      }
-    }
-
-    if (i_chars >= search_size) {
-      return i_str;
-    }
-  }
-
-  return data_size;
-}
-
-#undef T_CHAR
+#endif  /* BH_COMMON_STRING_UTIL_INTERNAL_MEMSTRING_MEMCRSPN_H_ */

--- a/src/bh/common/string_util/internal/memstring/memcrspn_template.h
+++ b/src/bh/common/string_util/internal/memstring/memcrspn_template.h
@@ -21,22 +21,16 @@
 
 #include <stddef.h>
 
+#include "bh/common/string_util/internal/memstring/memcrspn.h"
+
 #if !defined(T_CHAR)
 #error Define T_CHAR to specify the templated character type.
 #endif  /* !defined(T_CHAR) */
 
-#if !defined(T_INPUT)
-#error Define T_INPUT to specify the templated parameter type.
-#endif  /* !defined(T_INPUT) */
-
-#if !defined(T_FUNC_NAME)
-#error Define T_FUNC_NAME to specify the function name.
-#endif  /* !defined(T_FUNC_NAME) */
-
-size_t T_FUNC_NAME(
-    const T_INPUT* data,
+size_t T_MemCRSpn(T_CHAR)(
+    const T_CHAR* data,
     size_t data_size,
-    const T_INPUT* search,
+    const T_CHAR* search,
     size_t search_size) {
   const T_CHAR* str;
   size_t i_str;
@@ -71,6 +65,4 @@ size_t T_FUNC_NAME(
   return data_size;
 }
 
-#undef T_FUNC_NAME
-#undef T_INPUT
 #undef T_CHAR

--- a/src/bh/common/string_util/internal/memstring/memcspn.c
+++ b/src/bh/common/string_util/internal/memstring/memcspn.c
@@ -19,50 +19,24 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#include <stddef.h>
-
 #include "bh/common/string_util/internal/memstring/memcspn.h"
 
-#if !defined(T_CHAR)
-#error Define T_CHAR to specify the templated character type.
-#endif  /* !defined(T_CHAR) */
+#include <wchar.h>
 
-size_t T_MemCSpn(T_CHAR)(
-    const T_CHAR* data,
+/**
+ * External
+ */
+
+size_t T_MemCSpn(void)(
+    const void* data,
     size_t data_size,
-    const T_CHAR* search,
+    const void* search,
     size_t search_size) {
-  const T_CHAR* str;
-  size_t i_str;
-  const T_CHAR* chars;
-
-  if (data_size <= 0) {
-    return 0;
-  }
-
-  if (search_size <= 0) {
-    return 0;
-  }
-
-  str = data;
-  chars = search;
-
-  /* Scan str for a character that is not in chars. */
-  for (i_str = 0; i_str < data_size; ++i_str) {
-    size_t i_chars;
-
-    for (i_chars = 0; i_chars < search_size; ++i_chars) {
-      if (str[i_str] == chars[i_chars]) {
-        break;
-      }
-    }
-
-    if (i_chars >= search_size) {
-      return i_str;
-    }
-  }
-
-  return data_size;
+  return T_MemCSpn(char)(data, data_size, search, search_size);
 }
 
-#undef T_CHAR
+#define T_CHAR char
+#include "bh/common/string_util/internal/memstring/memcspn_template.h"
+
+#define T_CHAR wchar_t
+#include "bh/common/string_util/internal/memstring/memcspn_template.h"

--- a/src/bh/common/string_util/internal/memstring/memcspn.h
+++ b/src/bh/common/string_util/internal/memstring/memcspn.h
@@ -19,50 +19,40 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#ifndef BH_COMMON_STRING_UTIL_INTERNAL_MEMSTRING_MEMCSPN_H_
+#define BH_COMMON_STRING_UTIL_INTERNAL_MEMSTRING_MEMCSPN_H_
+
 #include <stddef.h>
+#include <wchar.h>
 
-#include "bh/common/string_util/internal/memstring/memcspn.h"
+#include "bh/common/preprocessor/template/identifier.h"
 
-#if !defined(T_CHAR)
-#error Define T_CHAR to specify the templated character type.
-#endif  /* !defined(T_CHAR) */
+#ifdef __cplusplus
+extern "C" {
+#endif  /* __cplusplus */
 
-size_t T_MemCSpn(T_CHAR)(
-    const T_CHAR* data,
+#define T_MemCSpn(T_CHAR) TEMPLATE_IDENTIFIER_1(T_MemCSpn, T_CHAR)
+
+size_t T_MemCSpn(void)(
+    const void* data,
     size_t data_size,
-    const T_CHAR* search,
-    size_t search_size) {
-  const T_CHAR* str;
-  size_t i_str;
-  const T_CHAR* chars;
+    const void* search,
+    size_t search_size);
 
-  if (data_size <= 0) {
-    return 0;
-  }
+size_t T_MemCSpn(char)(
+    const char* data,
+    size_t data_size,
+    const char* search,
+    size_t search_size);
 
-  if (search_size <= 0) {
-    return 0;
-  }
+size_t T_MemCSpn(wchar_t)(
+    const wchar_t* data,
+    size_t data_size,
+    const wchar_t* search,
+    size_t search_size);
 
-  str = data;
-  chars = search;
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif  /* __cplusplus */
 
-  /* Scan str for a character that is not in chars. */
-  for (i_str = 0; i_str < data_size; ++i_str) {
-    size_t i_chars;
-
-    for (i_chars = 0; i_chars < search_size; ++i_chars) {
-      if (str[i_str] == chars[i_chars]) {
-        break;
-      }
-    }
-
-    if (i_chars >= search_size) {
-      return i_str;
-    }
-  }
-
-  return data_size;
-}
-
-#undef T_CHAR
+#endif  /* BH_COMMON_STRING_UTIL_INTERNAL_MEMSTRING_MEMCSPN_H_ */

--- a/src/bh/common/string_util/internal/memstring/memrspn.c
+++ b/src/bh/common/string_util/internal/memstring/memrspn.c
@@ -19,50 +19,24 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#include <stddef.h>
+#include "bh/common/string_util/internal/memstring/memrspn.h"
 
-#include "bh/common/string_util/internal/memstring/memcspn.h"
+#include <wchar.h>
 
-#if !defined(T_CHAR)
-#error Define T_CHAR to specify the templated character type.
-#endif  /* !defined(T_CHAR) */
+/**
+ * External
+ */
 
-size_t T_MemCSpn(T_CHAR)(
-    const T_CHAR* data,
+size_t T_MemRSpn(void)(
+    const void* data,
     size_t data_size,
-    const T_CHAR* search,
+    const void* search,
     size_t search_size) {
-  const T_CHAR* str;
-  size_t i_str;
-  const T_CHAR* chars;
-
-  if (data_size <= 0) {
-    return 0;
-  }
-
-  if (search_size <= 0) {
-    return 0;
-  }
-
-  str = data;
-  chars = search;
-
-  /* Scan str for a character that is not in chars. */
-  for (i_str = 0; i_str < data_size; ++i_str) {
-    size_t i_chars;
-
-    for (i_chars = 0; i_chars < search_size; ++i_chars) {
-      if (str[i_str] == chars[i_chars]) {
-        break;
-      }
-    }
-
-    if (i_chars >= search_size) {
-      return i_str;
-    }
-  }
-
-  return data_size;
+  return T_MemRSpn(char)(data, data_size, search, search_size);
 }
 
-#undef T_CHAR
+#define T_CHAR char
+#include "bh/common/string_util/internal/memstring/memrspn_template.h"
+
+#define T_CHAR wchar_t
+#include "bh/common/string_util/internal/memstring/memrspn_template.h"

--- a/src/bh/common/string_util/internal/memstring/memrspn.h
+++ b/src/bh/common/string_util/internal/memstring/memrspn.h
@@ -19,50 +19,40 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#ifndef BH_COMMON_STRING_UTIL_INTERNAL_MEMSTRING_MEMRSPN_H_
+#define BH_COMMON_STRING_UTIL_INTERNAL_MEMSTRING_MEMRSPN_H_
+
 #include <stddef.h>
+#include <wchar.h>
 
-#include "bh/common/string_util/internal/memstring/memcspn.h"
+#include "bh/common/preprocessor/template/identifier.h"
 
-#if !defined(T_CHAR)
-#error Define T_CHAR to specify the templated character type.
-#endif  /* !defined(T_CHAR) */
+#ifdef __cplusplus
+extern "C" {
+#endif  /* __cplusplus */
 
-size_t T_MemCSpn(T_CHAR)(
-    const T_CHAR* data,
+#define T_MemRSpn(T_CHAR) TEMPLATE_IDENTIFIER_1(T_MemRSpn, T_CHAR)
+
+size_t T_MemRSpn(void)(
+    const void* data,
     size_t data_size,
-    const T_CHAR* search,
-    size_t search_size) {
-  const T_CHAR* str;
-  size_t i_str;
-  const T_CHAR* chars;
+    const void* search,
+    size_t search_size);
 
-  if (data_size <= 0) {
-    return 0;
-  }
+size_t T_MemRSpn(char)(
+    const char* data,
+    size_t data_size,
+    const char* search,
+    size_t search_size);
 
-  if (search_size <= 0) {
-    return 0;
-  }
+size_t T_MemRSpn(wchar_t)(
+    const wchar_t* data,
+    size_t data_size,
+    const wchar_t* search,
+    size_t search_size);
 
-  str = data;
-  chars = search;
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif  /* __cplusplus */
 
-  /* Scan str for a character that is not in chars. */
-  for (i_str = 0; i_str < data_size; ++i_str) {
-    size_t i_chars;
-
-    for (i_chars = 0; i_chars < search_size; ++i_chars) {
-      if (str[i_str] == chars[i_chars]) {
-        break;
-      }
-    }
-
-    if (i_chars >= search_size) {
-      return i_str;
-    }
-  }
-
-  return data_size;
-}
-
-#undef T_CHAR
+#endif  /* BH_COMMON_STRING_UTIL_INTERNAL_MEMSTRING_MEMRSPN_H_ */

--- a/src/bh/common/string_util/internal/memstring/memspn.c
+++ b/src/bh/common/string_util/internal/memstring/memspn.c
@@ -19,50 +19,24 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#include <stddef.h>
+#include "bh/common/string_util/internal/memstring/memspn.h"
 
-#include "bh/common/string_util/internal/memstring/memcspn.h"
+#include <wchar.h>
 
-#if !defined(T_CHAR)
-#error Define T_CHAR to specify the templated character type.
-#endif  /* !defined(T_CHAR) */
+/**
+ * External
+ */
 
-size_t T_MemCSpn(T_CHAR)(
-    const T_CHAR* data,
+size_t T_MemSpn(void)(
+    const void* data,
     size_t data_size,
-    const T_CHAR* search,
+    const void* search,
     size_t search_size) {
-  const T_CHAR* str;
-  size_t i_str;
-  const T_CHAR* chars;
-
-  if (data_size <= 0) {
-    return 0;
-  }
-
-  if (search_size <= 0) {
-    return 0;
-  }
-
-  str = data;
-  chars = search;
-
-  /* Scan str for a character that is not in chars. */
-  for (i_str = 0; i_str < data_size; ++i_str) {
-    size_t i_chars;
-
-    for (i_chars = 0; i_chars < search_size; ++i_chars) {
-      if (str[i_str] == chars[i_chars]) {
-        break;
-      }
-    }
-
-    if (i_chars >= search_size) {
-      return i_str;
-    }
-  }
-
-  return data_size;
+  return T_MemSpn(char)(data, data_size, search, search_size);
 }
 
-#undef T_CHAR
+#define T_CHAR char
+#include "bh/common/string_util/internal/memstring/memspn_template.h"
+
+#define T_CHAR wchar_t
+#include "bh/common/string_util/internal/memstring/memspn_template.h"

--- a/src/bh/common/string_util/internal/memstring/memspn.h
+++ b/src/bh/common/string_util/internal/memstring/memspn.h
@@ -19,50 +19,40 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#ifndef BH_COMMON_STRING_UTIL_INTERNAL_MEMSTRING_MEMSPN_H_
+#define BH_COMMON_STRING_UTIL_INTERNAL_MEMSTRING_MEMSPN_H_
+
 #include <stddef.h>
+#include <wchar.h>
 
-#include "bh/common/string_util/internal/memstring/memcspn.h"
+#include "bh/common/preprocessor/template/identifier.h"
 
-#if !defined(T_CHAR)
-#error Define T_CHAR to specify the templated character type.
-#endif  /* !defined(T_CHAR) */
+#ifdef __cplusplus
+extern "C" {
+#endif  /* __cplusplus */
 
-size_t T_MemCSpn(T_CHAR)(
-    const T_CHAR* data,
+#define T_MemSpn(T_CHAR) TEMPLATE_IDENTIFIER_1(T_MemSpn, T_CHAR)
+
+size_t T_MemSpn(void)(
+    const void* data,
     size_t data_size,
-    const T_CHAR* search,
-    size_t search_size) {
-  const T_CHAR* str;
-  size_t i_str;
-  const T_CHAR* chars;
+    const void* search,
+    size_t search_size);
 
-  if (data_size <= 0) {
-    return 0;
-  }
+size_t T_MemSpn(char)(
+    const char* data,
+    size_t data_size,
+    const char* search,
+    size_t search_size);
 
-  if (search_size <= 0) {
-    return 0;
-  }
+size_t T_MemSpn(wchar_t)(
+    const wchar_t* data,
+    size_t data_size,
+    const wchar_t* search,
+    size_t search_size);
 
-  str = data;
-  chars = search;
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif  /* __cplusplus */
 
-  /* Scan str for a character that is not in chars. */
-  for (i_str = 0; i_str < data_size; ++i_str) {
-    size_t i_chars;
-
-    for (i_chars = 0; i_chars < search_size; ++i_chars) {
-      if (str[i_str] == chars[i_chars]) {
-        break;
-      }
-    }
-
-    if (i_chars >= search_size) {
-      return i_str;
-    }
-  }
-
-  return data_size;
-}
-
-#undef T_CHAR
+#endif  /* BH_COMMON_STRING_UTIL_INTERNAL_MEMSTRING_MEMSPN_H_ */

--- a/src/bh/common/string_util/internal/memstring/memspn_template.h
+++ b/src/bh/common/string_util/internal/memstring/memspn_template.h
@@ -21,22 +21,16 @@
 
 #include <stddef.h>
 
+#include "bh/common/string_util/internal/memstring/memspn.h"
+
 #if !defined(T_CHAR)
 #error Define T_CHAR to specify the templated character type.
 #endif  /* !defined(T_CHAR) */
 
-#if !defined(T_INPUT)
-#error Define T_INPUT to specify the templated parameter type.
-#endif  /* !defined(T_INPUT) */
-
-#if !defined(T_FUNC_NAME)
-#error Define T_FUNC_NAME to specify the function name.
-#endif  /* !defined(T_FUNC_NAME) */
-
-size_t T_FUNC_NAME(
-    const T_INPUT* data,
+size_t T_MemSpn(T_CHAR)(
+    const T_CHAR* data,
     size_t data_size,
-    const T_INPUT* search,
+    const T_CHAR* search,
     size_t search_size) {
   const T_CHAR* str;
   size_t i_str;
@@ -66,6 +60,4 @@ size_t T_FUNC_NAME(
   return data_size;
 }
 
-#undef T_FUNC_NAME
-#undef T_INPUT
 #undef T_CHAR

--- a/src/bh/common/string_util/internal/memstring/memstr.c
+++ b/src/bh/common/string_util/internal/memstring/memstr.c
@@ -19,45 +19,21 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-#include <stddef.h>
+#include "bh/common/string_util/internal/memstring/memstr.h"
 
-#include "bh/common/string_util/internal/memstring/memrspn.h"
+#include <wchar.h>
 
-#if !defined(T_CHAR)
-#error Define T_CHAR to specify the templated character type.
-#endif  /* !defined(T_CHAR) */
+/**
+ * External
+ */
 
-size_t T_MemRSpn(T_CHAR)(
-    const T_CHAR* data,
-    size_t data_size,
-    const T_CHAR* search,
-    size_t search_size) {
-  const T_CHAR* str;
-  size_t i_str;
-  const T_CHAR* chars;
-  size_t i_chars;
-
-  if (data_size <= 0) {
-    return data_size;
-  }
-
-  if (search_size <= 0) {
-    return data_size;
-  }
-
-  str = data;
-  chars = search;
-
-  /* Scan str for a character that is in chars. */
-  for (i_str = data_size; i_str-- > 0; ) {
-    for (i_chars = 0; i_chars < search_size; ++i_chars) {
-      if (str[i_str] == chars[i_chars]) {
-        return i_str;
-      }
-    }
-  }
-
-  return data_size;
+void* T_MemStr(void)(
+    const void* data, size_t data_size, const void* sub, size_t sub_size) {
+  return T_MemStr(char)(data, data_size, sub, sub_size);
 }
 
-#undef T_CHAR
+#define T_CHAR char
+#include "bh/common/string_util/internal/memstring/memstr_template.h"
+
+#define T_CHAR wchar_t
+#include "bh/common/string_util/internal/memstring/memstr_template.h"

--- a/src/bh/common/string_util/internal/memstring/memstr.h
+++ b/src/bh/common/string_util/internal/memstring/memstr.h
@@ -19,50 +19,34 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#ifndef BH_COMMON_STRING_UTIL_INTERNAL_MEMSTRING_MEMSTR_H_
+#define BH_COMMON_STRING_UTIL_INTERNAL_MEMSTRING_MEMSTR_H_
+
 #include <stddef.h>
+#include <wchar.h>
 
-#include "bh/common/string_util/internal/memstring/memcspn.h"
+#include "bh/common/preprocessor/template/identifier.h"
 
-#if !defined(T_CHAR)
-#error Define T_CHAR to specify the templated character type.
-#endif  /* !defined(T_CHAR) */
+#ifdef __cplusplus
+extern "C" {
+#endif  /* __cplusplus */
 
-size_t T_MemCSpn(T_CHAR)(
-    const T_CHAR* data,
+#define T_MemStr(T_CHAR) TEMPLATE_IDENTIFIER_1(T_MemStr, T_CHAR)
+
+void* T_MemStr(void)(
+    const void* data, size_t data_size, const void* sub, size_t sub_size);
+
+char* T_MemStr(char)(
+    const char* data, size_t data_size, const char* sub, size_t sub_size);
+
+wchar_t* T_MemStr(wchar_t)(
+    const wchar_t* data,
     size_t data_size,
-    const T_CHAR* search,
-    size_t search_size) {
-  const T_CHAR* str;
-  size_t i_str;
-  const T_CHAR* chars;
+    const wchar_t* sub,
+    size_t sub_size);
 
-  if (data_size <= 0) {
-    return 0;
-  }
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif  /* __cplusplus */
 
-  if (search_size <= 0) {
-    return 0;
-  }
-
-  str = data;
-  chars = search;
-
-  /* Scan str for a character that is not in chars. */
-  for (i_str = 0; i_str < data_size; ++i_str) {
-    size_t i_chars;
-
-    for (i_chars = 0; i_chars < search_size; ++i_chars) {
-      if (str[i_str] == chars[i_chars]) {
-        break;
-      }
-    }
-
-    if (i_chars >= search_size) {
-      return i_str;
-    }
-  }
-
-  return data_size;
-}
-
-#undef T_CHAR
+#endif  /* BH_COMMON_STRING_UTIL_INTERNAL_MEMSTRING_MEMSTR_H_ */

--- a/src/bh/common/string_util/internal/memstring/memstr_template.h
+++ b/src/bh/common/string_util/internal/memstring/memstr_template.h
@@ -21,30 +21,18 @@
 
 #include <stddef.h>
 
+#include "bh/common/string_util/internal/memstring/memchr.h"
+#include "bh/common/string_util/internal/memstring/memcmp.h"
+#include "bh/common/string_util/internal/memstring/memstr.h"
+
 #if !defined(T_CHAR)
 #error Define T_CHAR to specify the templated character type.
 #endif  /* !defined(T_CHAR) */
 
-#if !defined(T_INPUT)
-#error Define T_INPUT to specify the templated parameter type.
-#endif  /* !defined(T_INPUT) */
-
-#if !defined(T_MEMCHR_FUNC_NAME)
-#error Define T_MEMCHR_FUNC_NAME to specify the memchr function name.
-#endif  /* !defined(T_MEMCHR_FUNC_NAME) */
-
-#if !defined(T_MEMCMP_FUNC_NAME)
-#error Define T_MEMCMP_FUNC_NAME to specify the memcmp function name.
-#endif  /* !defined(T_MEMCMP_FUNC_NAME) */
-
-#if !defined(T_FUNC_NAME)
-#error Define T_FUNC_NAME to specify the function name.
-#endif  /* !defined(T_FUNC_NAME) */
-
-T_INPUT* T_FUNC_NAME(
-    const T_INPUT* data,
+T_CHAR* T_MemStr(T_CHAR)(
+    const T_CHAR* data,
     size_t data_size,
-    const T_INPUT* sub,
+    const T_CHAR* sub,
     size_t sub_size) {
   const T_CHAR* str;
   const T_CHAR* substr;
@@ -71,22 +59,15 @@ T_INPUT* T_FUNC_NAME(
       return NULL;
     }
 
-    compare_result = T_MEMCMP_FUNC_NAME(first_ch, sub, sub_size);
+    compare_result = T_MemCmp(T_CHAR)(first_ch, sub, sub_size);
     if (compare_result == 0) {
       return (T_CHAR*)first_ch;
     }
 
-    first_ch =
-        T_MEMCHR_FUNC_NAME(&first_ch[1], substr[0], str_remaining_size);
+    first_ch = T_MemChr(T_CHAR)(&first_ch[1], substr[0], str_remaining_size);
   } while (first_ch != NULL);
 
   return NULL;
 }
 
-#undef T_FUNC_NAME
-
-#undef T_MEMCMP_FUNC_NAME
-#undef T_MEMCHR_FUNC_NAME
-
-#undef T_INPUT
 #undef T_CHAR

--- a/src/bh/common/string_util/memstring.c
+++ b/src/bh/common/string_util/memstring.c
@@ -22,83 +22,91 @@
 #include "bh/common/string_util/memstring.h"
 
 #include <stddef.h>
-#include <string.h>
 #include <wchar.h>
+
+#include "bh/common/string_util/internal/memstring/memcrspn.h"
+#include "bh/common/string_util/internal/memstring/memcspn.h"
+#include "bh/common/string_util/internal/memstring/memrspn.h"
+#include "bh/common/string_util/internal/memstring/memspn.h"
+#include "bh/common/string_util/internal/memstring/memstr.h"
 
 /**
  * External
  */
 
-/**
- * Define memcrspn
- */
+size_t MemCRSpn(
+    const void* data,
+    size_t data_size,
+    const void* search,
+    size_t search_size) {
+  return T_MemCRSpn(void)(data, data_size, search, search_size);
+}
 
-#define T_CHAR char
-#define T_INPUT void
-#define T_FUNC_NAME MemCRSpn
-#include "bh/common/string_util/internal/memstring/memcrspn_template.h"
+size_t WMemCRSpn(
+    const wchar_t* data,
+    size_t data_size,
+    const wchar_t* search,
+    size_t search_size) {
+  return T_MemCRSpn(wchar_t)(data, data_size, search, search_size);
+}
 
-#define T_CHAR wchar_t
-#define T_INPUT wchar_t
-#define T_FUNC_NAME WMemCRSpn
-#include "bh/common/string_util/internal/memstring/memcrspn_template.h"
+size_t MemCSpn(
+    const void* data,
+    size_t data_size,
+    const void* search,
+    size_t search_size) {
+  return T_MemCSpn(void)(data, data_size, search, search_size);
+}
 
-/**
- * Define memcspn
- */
+size_t WMemCSpn(
+    const wchar_t* data,
+    size_t data_size,
+    const wchar_t* search,
+    size_t search_size) {
+  return T_MemCSpn(wchar_t)(data, data_size, search, search_size);
+}
 
-#define T_CHAR char
-#define T_INPUT void
-#define T_FUNC_NAME MemCSpn
-#include "bh/common/string_util/internal/memstring/memcspn_template.h"
+size_t MemRSpn(
+    const void* data,
+    size_t data_size,
+    const void* search,
+    size_t search_size) {
+  return T_MemRSpn(void)(data, data_size, search, search_size);
+}
 
-#define T_CHAR wchar_t
-#define T_INPUT wchar_t
-#define T_FUNC_NAME WMemCSpn
-#include "bh/common/string_util/internal/memstring/memcspn_template.h"
+size_t WMemRSpn(
+    const wchar_t* data,
+    size_t data_size,
+    const wchar_t* search,
+    size_t search_size) {
+  return T_MemRSpn(wchar_t)(data, data_size, search, search_size);
+}
 
-/**
- * Define memrspn
- */
+size_t MemSpn(
+    const void* data,
+    size_t data_size,
+    const void* search,
+    size_t search_size) {
+  return T_MemSpn(void)(data, data_size, search, search_size);
+}
 
-#define T_CHAR char
-#define T_INPUT void
-#define T_FUNC_NAME MemRSpn
-#include "bh/common/string_util/internal/memstring/memrspn_template.h"
+size_t WMemSpn(
+    const wchar_t* data,
+    size_t data_size,
+    const wchar_t* search,
+    size_t search_size) {
+  return T_MemSpn(wchar_t)(data, data_size, search, search_size);
+}
 
-#define T_CHAR wchar_t
-#define T_INPUT wchar_t
-#define T_FUNC_NAME WMemRSpn
-#include "bh/common/string_util/internal/memstring/memrspn_template.h"
+void* MemStr(
+    const void* data, size_t data_size, const void* sub, size_t sub_size) {
+  return T_MemStr(void)(data, data_size, sub, sub_size);
+}
 
-/**
- * Define memspn
- */
-
-#define T_CHAR char
-#define T_INPUT void
-#define T_FUNC_NAME MemSpn
-#include "bh/common/string_util/internal/memstring/memspn_template.h"
-
-#define T_CHAR wchar_t
-#define T_INPUT wchar_t
-#define T_FUNC_NAME WMemSpn
-#include "bh/common/string_util/internal/memstring/memspn_template.h"
-
-/**
- * Define memstr
- */
-
-#define T_CHAR char
-#define T_INPUT void
-#define T_MEMCHR_FUNC_NAME memchr
-#define T_MEMCMP_FUNC_NAME memcmp
-#define T_FUNC_NAME MemStr
-#include "bh/common/string_util/internal/memstring/memstr_template.h"
-
-#define T_CHAR wchar_t
-#define T_INPUT wchar_t
-#define T_MEMCHR_FUNC_NAME wmemchr
-#define T_MEMCMP_FUNC_NAME wmemcmp
-#define T_FUNC_NAME WMemStr
-#include "bh/common/string_util/internal/memstring/memstr_template.h"
+wchar_t* WMemStr(
+    const wchar_t* data,
+    size_t data_size,
+    const wchar_t* sub,
+    size_t sub_size) {
+  return T_MemStr(wchar_t)(data, data_size, sub, sub_size);
+}

--- a/src/bh/common/string_util/memstring.h
+++ b/src/bh/common/string_util/memstring.h
@@ -45,9 +45,9 @@ size_t MemCRSpn(
  * the reverse direction.
  */
 size_t WMemCRSpn(
-    const void* data,
+    const wchar_t* data,
     size_t data_size,
-    const void* search,
+    const wchar_t* search,
     size_t search_size);
 
 /**
@@ -87,9 +87,9 @@ size_t MemRSpn(
  * the reverse direction.
  */
 size_t WMemRSpn(
-    const void* data,
+    const wchar_t* data,
     size_t data_size,
-    const void* search,
+    const wchar_t* search,
     size_t search_size);
 
 /**


### PR DESCRIPTION
These changes reduce the number of parameters specified in C template functions by using macros to generate templated function identifiers. This does not affect how the libraries are used externally, making it useful for internal implementation.